### PR TITLE
adding TOO_MANY_AUTH_ATTEMPTS functionality and tests

### DIFF
--- a/src/main/java/io/deepstream/DeepstreamClient.java
+++ b/src/main/java/io/deepstream/DeepstreamClient.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.deepstream.constants.ConnectionState;
+import io.deepstream.constants.Event;
+import io.deepstream.constants.Topic;
 import io.deepstream.event.EventHandler;
 import io.deepstream.message.Connection;
 import org.json.JSONObject;
@@ -23,12 +25,12 @@ public class DeepstreamClient {
         this( url, new HashMap() );
     }
 
-    public DeepstreamClient login( JSONObject data ) {
+    public DeepstreamClient login( JSONObject data ) throws Exception {
         this.connection.authenticate( data, null );
         return this;
     }
 
-    public DeepstreamClient login( JSONObject data, LoginCallback loginCallback ) {
+    public DeepstreamClient login( JSONObject data, LoginCallback loginCallback ) throws Exception {
         this.connection.authenticate( data, loginCallback );
         return this;
     }
@@ -51,4 +53,12 @@ public class DeepstreamClient {
         return this.connection.getConnectionState();
     }
 
+    public void onError(Topic topic, Event event, String message) throws DeepstreamException {
+        System.out.println( "--- You can catch all deepstream errors by subscribing to the error event ---" );
+
+        String errorMsg = event + ": " + message;
+        errorMsg += " (" + topic + ")";
+
+        throw new DeepstreamException( errorMsg );
+    }
 }

--- a/src/main/java/io/deepstream/DeepstreamException.java
+++ b/src/main/java/io/deepstream/DeepstreamException.java
@@ -1,0 +1,14 @@
+package io.deepstream;
+
+/**
+ * Created by Alex on 15/05/2016.
+ */
+public class DeepstreamException extends RuntimeException {
+
+    public DeepstreamException() {
+        super();
+    }
+    public DeepstreamException( String message ) {
+        super( message );
+    }
+}

--- a/src/test/java/io/socket/engineio/client/Socket.java
+++ b/src/test/java/io/socket/engineio/client/Socket.java
@@ -21,7 +21,7 @@ public class Socket extends Emitter {
         this.lastSentMessage = null;
         this.url = url;
         this.isDisconnected = true;
-        this.sentMessages = new ArrayList<>();
+        this.sentMessages = new ArrayList<String>();
     }
 
     public Socket open() {


### PR DESCRIPTION
When authenticating the and there have been too many auth attempts, should throw an error. Additional checks to see whether there are any 'error' listeners (in which case the exception is not thrown) can be added later.

