### PR TITLE
Fixing broken login method

### DIFF
--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -1,6 +1,7 @@
 package io.deepstream;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import io.deepstream.constants.*;
 
 import java.net.URISyntaxException;
@@ -118,7 +119,12 @@ class Connection implements IConnection {
      */
     private void sendAuthMessage() {
         setState( ConnectionState.AUTHENTICATING );
-        String authMessage = MessageBuilder.getMsg( Topic.AUTH, Actions.REQUEST, this.authParameters.toString() );
+        String authMessage;
+        if( this.authParameters == null ) {
+            authMessage = MessageBuilder.getMsg(Topic.AUTH, Actions.REQUEST, new JsonObject().toString());
+        } else {
+            authMessage = MessageBuilder.getMsg(Topic.AUTH, Actions.REQUEST, authParameters.toString());
+        }
         this.endpoint.send( authMessage );
     }
 

--- a/src/test/java/io/deepstream/ConnectionTest.java
+++ b/src/test/java/io/deepstream/ConnectionTest.java
@@ -83,6 +83,16 @@ public class ConnectionTest {
     }
 
     @Test
+    public void sendingAuthenticationWithNoParams() throws Exception {
+        this.challengeAck();
+        JsonObject authParams = new JsonObject();
+        connection.authenticate( authParams, loginCallback );
+
+        assertEquals(endpointMock.lastSentMessage, MessageBuilder.getMsg( Topic.AUTH, Actions.REQUEST, "{}" ));
+        verifyConnectionState( ConnectionState.AUTHENTICATING );
+    }
+
+    @Test
     public void gettingValidAuthenticationBack() throws Exception {
         this.sendingAuthentication();
 


### PR DESCRIPTION
Currently 

`client.login()` sends `A|REQ+` which the server doesn't like

with this PR it sends `A|REQ|{}+` which is consistent with the js client