### PR TITLE
Changes for iOS client

### DIFF
--- a/build-prod.gradle
+++ b/build-prod.gradle
@@ -50,15 +50,12 @@ j2objcConfig {
         include '**/*Test.java'
     }
 
-    xcodeProjectDir '../DeepstreamIO/'
-    xcodeTargetsIos 'DeepstreamIO'
-
     translateArgs "--no-package-directories", "-use-arc", "--build-closure", "--nullability"
     translateArgs "--strip-gwt-incompatible"
     translateArgs "--prefixes", "${projectDir}/prefixes.properties"
     translateArgs "--doc-comments"
 
-    extraObjcCompilerArgs '-fobjc-arc'
+    extraObjcCompilerArgs '-fobjc-arc', '-fembed-bitcode'
     finalConfigure() // Must be last call to configuration
 }
 

--- a/build-prod.gradle
+++ b/build-prod.gradle
@@ -43,7 +43,6 @@ dependencies {
 }
 
 j2objcConfig {
-    // Sets up libraries you depend on
     skipJ2objcVerification true
     autoConfigureDeps true
     supportedArchs += ['ios_i386']
@@ -51,11 +50,15 @@ j2objcConfig {
         include '**/*Test.java'
     }
 
+    xcodeProjectDir '../DeepstreamIO/'
+    xcodeTargetsIos 'DeepstreamIO'
+
     translateArgs "--no-package-directories", "-use-arc", "--build-closure"
     translateArgs "--prefixes", "${projectDir}/prefixes.properties"
     translateArgs "--doc-comments"
 
-    finalConfigure()          // Must be last call to configuration
+    extraObjcCompilerArgs '-fobjc-arc'
+    finalConfigure() // Must be last call to configuration
 }
 
 group 'io.deepstream'

--- a/build-prod.gradle
+++ b/build-prod.gradle
@@ -53,7 +53,8 @@ j2objcConfig {
     xcodeProjectDir '../DeepstreamIO/'
     xcodeTargetsIos 'DeepstreamIO'
 
-    translateArgs "--no-package-directories", "-use-arc", "--build-closure"
+    translateArgs "--no-package-directories", "-use-arc", "--build-closure", "--nullability"
+    translateArgs "--strip-gwt-incompatible"
     translateArgs "--prefixes", "${projectDir}/prefixes.properties"
     translateArgs "--doc-comments"
 

--- a/build-prod.gradle
+++ b/build-prod.gradle
@@ -36,6 +36,7 @@ sourceSets {
 
 dependencies {
     compile 'com.google.code.gson:gson:2.6.2'
+    compile 'com.google.j2objc:j2objc-annotations:1.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile "org.mockito:mockito-core:1.+"

--- a/build-prod.gradle
+++ b/build-prod.gradle
@@ -49,6 +49,11 @@ j2objcConfig {
     testPattern {
         include '**/*Test.java'
     }
+
+    translateArgs "--no-package-directories", "-use-arc", "--build-closure"
+    translateArgs "--prefixes", "${projectDir}/prefixes.properties"
+    translateArgs "--doc-comments"
+
     finalConfigure()          // Must be last call to configuration
 }
 

--- a/prefixes.properties
+++ b/prefixes.properties
@@ -1,0 +1,7 @@
+io.deepstream:
+com.google.gson:
+com.google.gson.internal:
+com.google.gson.internal.bind:
+com.google.gson.annotations:
+com.google.gson.reflect:
+com.google.gson.stream:

--- a/src/main/java/io/deepstream/Actions.java
+++ b/src/main/java/io/deepstream/Actions.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -130,10 +132,12 @@ public enum Actions {
 
     private String action;
 
+
     Actions( String action ) {
         this.action = action;
     }
 
+    @ObjectiveCName("getAction:")
     static Actions getAction( String action ) {
         return lookup.get( action );
     }

--- a/src/main/java/io/deepstream/Actions.java
+++ b/src/main/java/io/deepstream/Actions.java
@@ -132,7 +132,7 @@ public enum Actions {
 
     private String action;
 
-
+    @ObjectiveCName("init:")
     Actions( String action ) {
         this.action = action;
     }

--- a/src/main/java/io/deepstream/AnonymousRecord.java
+++ b/src/main/java/io/deepstream/AnonymousRecord.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 import java.util.ArrayList;
@@ -28,6 +30,7 @@ public class AnonymousRecord {
      * This constructor is called by the {@link RecordHandler#getAnonymousRecord()}
      * @param recordHandler The recordHandler used to get record instances
      */
+    @ObjectiveCName("init:")
     AnonymousRecord(RecordHandler recordHandler) {
         this.recordHandler = recordHandler;
         this.subscriptions = new ArrayList<>();
@@ -52,6 +55,7 @@ public class AnonymousRecord {
      * @param anonymousRecordNameChangedCallback The listener to add
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("addRecordNameChangedListener:")
     public AnonymousRecord addRecordNameChangedListener(AnonymousRecordNameChangedListener anonymousRecordNameChangedCallback ) {
         this.anonymousRecordNameChangedCallbacks.add( anonymousRecordNameChangedCallback );
         return this;
@@ -62,6 +66,7 @@ public class AnonymousRecord {
      * @param anonymousRecordNameChangedCallback The listener to remove
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("removeRecordNameChangedCallback:")
     public AnonymousRecord removeRecordNameChangedCallback(AnonymousRecordNameChangedListener anonymousRecordNameChangedCallback ) {
         this.anonymousRecordNameChangedCallbacks.remove( anonymousRecordNameChangedCallback );
         return this;
@@ -73,6 +78,7 @@ public class AnonymousRecord {
      * the method returns null
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("set:")
     public AnonymousRecord set( Object data ) throws AnonymousRecordUninitialized {
         return this.set( null, data );
     }
@@ -83,6 +89,7 @@ public class AnonymousRecord {
      * the method returns null
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("set:Object:")
     public AnonymousRecord set( String path, Object data ) throws AnonymousRecordUninitialized {
         if( this.record == null ) {
             throw new AnonymousRecordUninitialized( "set" );
@@ -137,6 +144,7 @@ public class AnonymousRecord {
      * @param path The path to retrieve
      * @return The JsonElement
      */
+    @ObjectiveCName("get:")
     public JsonElement get(String path ) {
         if( this.record == null ) {
             return null;
@@ -149,6 +157,7 @@ public class AnonymousRecord {
      * @param recordChangedCallback The listener to add
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("subscribe:")
     public AnonymousRecord subscribe( RecordChangedCallback recordChangedCallback ) {
         this.subscriptions.add( new Subscription( recordChangedCallback ) );
 
@@ -167,6 +176,7 @@ public class AnonymousRecord {
      * @param recordPathChangedCallback The listener to add
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("subscribe:recordPathChangedCallback:")
     public AnonymousRecord subscribe( String path, RecordPathChangedCallback recordPathChangedCallback ) {
         this.subscriptions.add( new Subscription( path, recordPathChangedCallback ) );
 
@@ -182,6 +192,7 @@ public class AnonymousRecord {
      * @param recordChangedCallback The listener to remove
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("unsubscribe:")
     public AnonymousRecord unsubscribe( RecordChangedCallback recordChangedCallback ) {
         for( Subscription subscription : subscriptions ) {
             if( subscription.recordChangedCallback == recordChangedCallback ) {
@@ -203,6 +214,7 @@ public class AnonymousRecord {
      * @param recordPathChangedCallback The listen to remove
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("unsubscribe:recordPathChangedCallback:")
     public AnonymousRecord unsubscribe( String path, RecordPathChangedCallback recordPathChangedCallback ) {
         for( Subscription subscription : subscriptions ) {
             if( subscription.path.equals( path ) && subscription.recordPathChangedCallback == recordPathChangedCallback ) {
@@ -223,6 +235,7 @@ public class AnonymousRecord {
      * @param recordEventListener The listener to add
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("addRecordEventsListener:")
     public AnonymousRecord addRecordEventsListener(RecordEventsListener recordEventListener ) {
         this.subscriptions.add( new Subscription( recordEventListener ) );
 
@@ -239,6 +252,7 @@ public class AnonymousRecord {
      * @param recordEventListener The listener to remove
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("removeRecordEventsListener:")
     public AnonymousRecord removeRecordEventsListener(RecordEventsListener recordEventListener ) {
         for( Subscription subscription : this.subscriptions ) {
             if( subscription.recordChangedCallback != null ) {
@@ -260,6 +274,7 @@ public class AnonymousRecord {
      * @param recordName The name of the underlying record to use
      * @return The AnonymousRecord
      */
+    @ObjectiveCName("setName:")
     public AnonymousRecord setName( String recordName ) {
         this.unsubscribeRecord();
         this.record = this.recordHandler.getRecord( recordName );

--- a/src/main/java/io/deepstream/AnonymousRecordNameChangedListener.java
+++ b/src/main/java/io/deepstream/AnonymousRecordNameChangedListener.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * A listener that notifies the user whenever {@link AnonymousRecord#setName(String)} is called
  */
@@ -9,5 +11,6 @@ public interface AnonymousRecordNameChangedListener {
      * @param recordName The new recordName
      * @param anonymousRecord The anonymousRecord which name changed
      */
+    @ObjectiveCName("recordNameChanged:anonymousRecord:")
     void recordNameChanged(String recordName, AnonymousRecord anonymousRecord );
 }

--- a/src/main/java/io/deepstream/AnonymousRecordUninitialized.java
+++ b/src/main/java/io/deepstream/AnonymousRecordUninitialized.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * An exception that is thrown if you try to do a {@link AnonymousRecord#discard()} or {@link AnonymousRecord#delete()}
  * before a record has been set via {@link AnonymousRecord#setName(String)}
@@ -11,6 +13,7 @@ public class AnonymousRecordUninitialized extends Exception {
      * This Exception is thrown by {@see AnonymousRecord} and should not be constructed by consumers of this library
      * @param methodName The method name that was called
      */
+    @ObjectiveCName("init:")
     AnonymousRecordUninitialized(String methodName) {
         super( "Can`t invoke " + methodName + ". AnonymousRecord not initialised. Call setName first" );
     }

--- a/src/main/java/io/deepstream/ConfigOptions.java
+++ b/src/main/java/io/deepstream/ConfigOptions.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.Properties;
 
 /**
@@ -69,6 +71,7 @@ public enum ConfigOptions {
 
     private String configOption;
 
+    @ObjectiveCName("init:")
     ConfigOptions(String topic) {
         this.configOption = topic;
     }

--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -1,7 +1,10 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.List;
@@ -45,6 +48,7 @@ class Connection implements IConnection {
      * @param client The deepstream client
      * @throws URISyntaxException An exception if an invalid url is passed in
      */
+    @ObjectiveCName("init:options:client:")
     Connection(final String url, final DeepstreamConfig options, DeepstreamClient client) throws URISyntaxException {
         this( url, options, client, null );
         this.endpoint = createEndpoint();
@@ -57,6 +61,7 @@ class Connection implements IConnection {
      * @param client The deepstream client
      * @param endpoint The endpoint, whether TCP, Engine.io, mock or anything else
      */
+    @ObjectiveCName("init:options:client:endpoint:")
     Connection(final String url, final DeepstreamConfig options, DeepstreamClient client, Endpoint endpoint) {
         this.client = client;
         this.connectStateListeners = new ArrayList<>();
@@ -84,6 +89,7 @@ class Connection implements IConnection {
      * @param loginCallback The callback for a successful / unsuccessful login attempt
      * connection
      */
+    @ObjectiveCName("authenticate:loginCallback:")
     void authenticate(JsonElement authParameters, DeepstreamClient.LoginCallback loginCallback) {
         this.loginCallback = loginCallback;
         this.authParameters = authParameters;
@@ -100,6 +106,7 @@ class Connection implements IConnection {
     }
 
     @Override
+    @ObjectiveCName("send:")
     public void send( String message ) {
         if( this.connectionState != ConnectionState.OPEN ) {
             this.messageBuffer.append( message );
@@ -109,6 +116,7 @@ class Connection implements IConnection {
     }
 
     @Override
+    @ObjectiveCName("sendMsg:action:data:")
     public void sendMsg( Topic topic, Actions action, String[] data ) {
         this.send( MessageBuilder.getMsg( topic, action, data ) );
     }
@@ -127,10 +135,12 @@ class Connection implements IConnection {
         this.endpoint.send( authMessage );
     }
 
+    @ObjectiveCName("addConnectionChangeListener:")
     void addConnectionChangeListener( ConnectionStateListener connectionStateListener) {
         this.connectStateListeners.add(connectionStateListener);
     }
 
+    @ObjectiveCName("removeConnectionChangeListener:")
     void removeConnectionChangeListener( ConnectionStateListener connectionStateListener) {
         this.connectStateListeners.remove(connectionStateListener);
     }
@@ -155,6 +165,7 @@ class Connection implements IConnection {
         this.setState( ConnectionState.AWAITING_CONNECTION );
     }
 
+    @ObjectiveCName("onError:")
     void onError(final String error ) {
         this.setState( ConnectionState.ERROR );
 
@@ -170,6 +181,7 @@ class Connection implements IConnection {
         }, 1000);
     }
 
+    @ObjectiveCName("onMessage:")
     void onMessage(String rawMessage) {
         List<Message> parsedMessages = MessageParser.parse( rawMessage, this.client );
         for (final Message message : parsedMessages) {
@@ -222,6 +234,7 @@ class Connection implements IConnection {
         }
     }
 
+    @ObjectiveCName("handleConnectionResponse:")
     private void handleConnectionResponse( Message message ) {
         if( message.action == Actions.ACK ) {
             this.setState( ConnectionState.AWAITING_AUTHENTICATION );
@@ -244,6 +257,7 @@ class Connection implements IConnection {
         }
     }
 
+    @ObjectiveCName("handleAuthResponse:")
     private void handleAuthResponse( Message message ) {
         if( message.action == Actions.ERROR ) {
             if( message.data[0].equals( Event.TOO_MANY_AUTH_ATTEMPTS.name() ) ) {
@@ -274,6 +288,7 @@ class Connection implements IConnection {
         }
     }
 
+    @ObjectiveCName("setState:")
     private void setState( ConnectionState connectionState ) {
         this.connectionState = connectionState;
 

--- a/src/main/java/io/deepstream/ConnectionStateListener.java
+++ b/src/main/java/io/deepstream/ConnectionStateListener.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * A listener that will be notified whenever the ConnectionState changes. Can be added via
  * {@link DeepstreamClient#addConnectionChangeListener(ConnectionStateListener)} and removed via
@@ -12,5 +14,6 @@ public interface ConnectionStateListener {
      * the connection drops.
      * @param connectionState The current connection state
      */
+    @ObjectiveCName("connectionStateChanged:")
     void connectionStateChanged(ConnectionState connectionState );
 }

--- a/src/main/java/io/deepstream/DeepstreamClient.java
+++ b/src/main/java/io/deepstream/DeepstreamClient.java
@@ -159,6 +159,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      * @param connectionStateListener The listener to add
      * @return The deepstream client
      */
+    @ObjectiveCName("addConnectionChangeListener:")
     public DeepstreamClient addConnectionChangeListener( ConnectionStateListener connectionStateListener) {
         this.connection.addConnectionChangeListener(connectionStateListener);
         return this;
@@ -169,6 +170,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      * @param connectionStateListener The listener to remove
      * @return The deepstream client
      */
+    @ObjectiveCName("removeConnectionChangeListener:")
     public DeepstreamClient removeConnectionChangeListener( ConnectionStateListener connectionStateListener) {
         this.connection.removeConnectionChangeListener(connectionStateListener);
         return this;

--- a/src/main/java/io/deepstream/DeepstreamClient.java
+++ b/src/main/java/io/deepstream/DeepstreamClient.java
@@ -2,6 +2,8 @@ package io.deepstream;
 
 import com.google.gson.JsonElement;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Properties;
@@ -40,6 +42,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      *
      * @throws URISyntaxException Thrown if the url in incorrect
      */
+    @ObjectiveCName("init:")
     public DeepstreamClient(final String url) throws URISyntaxException {
         this(url, new DeepstreamConfig());
     }
@@ -49,6 +52,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      *
      * @throws URISyntaxException Thrown if the url in incorrect
      */
+    @ObjectiveCName("init:properties:")
     public DeepstreamClient(final String url, Properties options) throws URISyntaxException, InvalidDeepstreamConfig {
         this(url, new DeepstreamConfig(options));
     }
@@ -59,6 +63,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      * @param deepstreamConfig A map of options that extend the ones specified in DefaultConfig.properties
      * @throws URISyntaxException Thrown if the url in incorrect
      */
+    @ObjectiveCName("init:deepstreamConfig:")
     private DeepstreamClient(final String url, DeepstreamConfig deepstreamConfig) throws URISyntaxException {
         this.connection = new Connection(url, deepstreamConfig, this);
         this.event = new EventHandler(deepstreamConfig, this.connection, this);
@@ -111,6 +116,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      * @param authParams JSON.serializable authentication data
      * @return The login result
      */
+    // @ObjectiveCName("loginWithAuthPara:")
     public LoginResult login(JsonElement authParams) {
         final CountDownLatch loggedInLatch = new CountDownLatch(1);
         final LoginResult[] loginResult = new LoginResult[1];

--- a/src/main/java/io/deepstream/DeepstreamClient.java
+++ b/src/main/java/io/deepstream/DeepstreamClient.java
@@ -77,6 +77,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      *
      * @param deepstreamRuntimeErrorHandler The listener to set
      */
+    @ObjectiveCName("setRuntimeErrorHandler:")
     public void setRuntimeErrorHandler( DeepstreamRuntimeErrorHandler deepstreamRuntimeErrorHandler )  {
         super.setRuntimeErrorHandler( deepstreamRuntimeErrorHandler );
     }
@@ -116,19 +117,21 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      * @param authParams JSON.serializable authentication data
      * @return The login result
      */
-    // @ObjectiveCName("loginWithAuthPara:")
+    @ObjectiveCName("login:")
     public LoginResult login(JsonElement authParams) {
         final CountDownLatch loggedInLatch = new CountDownLatch(1);
         final LoginResult[] loginResult = new LoginResult[1];
 
         this.connection.authenticate(authParams, new LoginCallback() {
             @Override
+            @ObjectiveCName("loginSuccess:")
             public void loginSuccess(Map userData) {
                 loginResult[0] = new LoginResult(true, userData);
                 loggedInLatch.countDown();
             }
 
             @Override
+            @ObjectiveCName("loginFailed:data:")
             public void loginFailed(Event errorEvent, Object data) {
                 loginResult[0] = new LoginResult(false, errorEvent, data);
                 loggedInLatch.countDown();
@@ -209,6 +212,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
          *
          * @param userData Optional data that is specific to the user and returned on succesfuly authentication
          */
+        @ObjectiveCName("loginSuccess:")
         void loginSuccess(Map userData);
 
         /**
@@ -217,6 +221,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
          * @param errorEvent error event
          * @param data       Contains data associated to the failed login, such as the reason
          */
+        @ObjectiveCName("loginFailed:data:")
         void loginFailed(Event errorEvent, Object data);
     }
 }

--- a/src/main/java/io/deepstream/DeepstreamClientAbstract.java
+++ b/src/main/java/io/deepstream/DeepstreamClientAbstract.java
@@ -29,10 +29,12 @@ abstract class DeepstreamClientAbstract {
      *
      * @param deepstreamRuntimeErrorHandler The listener to set
      */
+    @ObjectiveCName("setRuntimeErrorHandler:")
     public void setRuntimeErrorHandler(DeepstreamRuntimeErrorHandler deepstreamRuntimeErrorHandler) {
         this.deepstreamRuntimeErrorHandler = deepstreamRuntimeErrorHandler;
     }
 
+    @ObjectiveCName("onError:event:msg:")
     void onError(Topic topic, Event event, String msg) throws DeepstreamException {
         /*
          * Help to diagnose the problem quicker by checking for

--- a/src/main/java/io/deepstream/DeepstreamClientAbstract.java
+++ b/src/main/java/io/deepstream/DeepstreamClientAbstract.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 abstract class DeepstreamClientAbstract {

--- a/src/main/java/io/deepstream/DeepstreamConfig.java
+++ b/src/main/java/io/deepstream/DeepstreamConfig.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.Properties;
 
 class DeepstreamConfig {
@@ -9,6 +11,7 @@ class DeepstreamConfig {
         properties = new Properties();
     }
 
+    @ObjectiveCName("init:")
     DeepstreamConfig( Properties properties ) throws InvalidDeepstreamConfig {
         this.properties = properties;
 
@@ -78,6 +81,7 @@ class DeepstreamConfig {
         return Integer.parseInt(getOption(ConfigOptions.RECORD_DELETE_TIMEOUT, "3000"));
     }
 
+    @ObjectiveCName("getOption:defaultValue:")
     private String getOption(ConfigOptions option, String defaultValue) {
         if (properties.containsKey(option)) {
             return properties.get(option).toString();

--- a/src/main/java/io/deepstream/DeepstreamError.java
+++ b/src/main/java/io/deepstream/DeepstreamError.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * DeepstreamErrors are used for expected error cases, such as during {@link RecordHandler#snapshot(String)} where the
  * result is either the data or a record not found error.
@@ -8,6 +10,7 @@ package io.deepstream;
  */
 public class DeepstreamError extends Exception {
 
+	@ObjectiveCName("init:")
     DeepstreamError(String error) {
         super(error);
     }

--- a/src/main/java/io/deepstream/DeepstreamException.java
+++ b/src/main/java/io/deepstream/DeepstreamException.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * A DeepstreamException is a RuntimeException since they mostly occur when receiving an out of sync message
  * from the server, or if an Ack has timed out. You can catch these via {@link DeepstreamClient#setRuntimeErrorHandler(DeepstreamRuntimeErrorHandler)}
@@ -22,11 +24,12 @@ public class DeepstreamException extends RuntimeException {
      */
     public String message;
 
-
+    @ObjectiveCName("init:")
     DeepstreamException(String message ) {
         super( message );
     }
 
+    @ObjectiveCName("init:event:message:")
     DeepstreamException(Topic topic, Event event, String message) {
         super( event + ": " + message );
         this.topic = topic;

--- a/src/main/java/io/deepstream/DeepstreamFactory.java
+++ b/src/main/java/io/deepstream/DeepstreamFactory.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,6 +53,7 @@ public class DeepstreamFactory {
      * @return A deepstream client
      * @throws URISyntaxException An error if the url syntax is invalid
      */
+    @ObjectiveCName("getClient:")
     public DeepstreamClient getClient(String url) throws URISyntaxException {
         DeepstreamClient client = this.clients.get(url);
         if (clientDoesNotExist(client)) {
@@ -70,6 +73,7 @@ public class DeepstreamFactory {
      * @throws URISyntaxException      An error if the url syntax is invalid
      * @throws InvalidDeepstreamConfig An exception if any of the options are invalid
      */
+    @ObjectiveCName("getClient:options:")
     public DeepstreamClient getClient(String url, Properties options) throws URISyntaxException, InvalidDeepstreamConfig {
         DeepstreamClient client = this.clients.get(url);
         if (clientDoesNotExist(client)) {
@@ -79,6 +83,7 @@ public class DeepstreamFactory {
         return client;
     }
 
+    @ObjectiveCName("clientDoesNotExist:")
     private boolean clientDoesNotExist(DeepstreamClient client) {
         return client == null || client.getConnectionState() == ConnectionState.CLOSED || client.getConnectionState() == ConnectionState.ERROR;
     }

--- a/src/main/java/io/deepstream/DeepstreamRecordDestroyedException.java
+++ b/src/main/java/io/deepstream/DeepstreamRecordDestroyedException.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * Called whenever you try to perform an action on a record that has been discarded/deleted. Retrieve a new instance of the
  * Record using {@link RecordHandler#getRecord(String)} to continue using it.
@@ -11,6 +13,7 @@ public class DeepstreamRecordDestroyedException extends RuntimeException {
      */
     public final String method;
 
+    @ObjectiveCName("init:")
     DeepstreamRecordDestroyedException(String method ) {
         this.method = method;
     }

--- a/src/main/java/io/deepstream/DeepstreamRuntimeErrorHandler.java
+++ b/src/main/java/io/deepstream/DeepstreamRuntimeErrorHandler.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * The expectations would be for java clients to implement this and add it
  * via the *setDeepstreamRuntimeErrorHandler* handler in order to catch all
@@ -20,5 +22,6 @@ public interface DeepstreamRuntimeErrorHandler {
      * @param event The Error Event
      * @param errorMessage The error message
      */
+    @ObjectiveCName("onException:event:errorMessage:")
     void onException(Topic topic, Event event, String errorMessage);
 }

--- a/src/main/java/io/deepstream/Endpoint.java
+++ b/src/main/java/io/deepstream/Endpoint.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * The interface required for any connection endpoints. Currently we support {@link EndpointType#ENGINEIO}
  * and {@link EndpointType#TCP}. Adding a custom endpoint would require you to fork the repo and can't
@@ -10,6 +12,7 @@ interface Endpoint {
      * Message to send to the deepstream server
      * @param message The message to send (TOPIC|ACTION|ARRAY+)
      */
+    @ObjectiveCName("send:")
     void send(String message);
 
     /**

--- a/src/main/java/io/deepstream/EndpointTCP.java
+++ b/src/main/java/io/deepstream/EndpointTCP.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -27,6 +29,7 @@ class EndpointTCP implements Endpoint {
     private OutputStreamWriter out;
     private InputStreamReader in;
 
+    @ObjectiveCName("init:deepstreamConfig:connection:")
     public EndpointTCP(String url, DeepstreamConfig deepstreamConfig, Connection connection) throws URISyntaxException {
         try {
             this.host = url.substring( 0, url.indexOf( ':' ) );
@@ -90,6 +93,7 @@ class EndpointTCP implements Endpoint {
         }).start();
     }
 
+     @ObjectiveCName("onError:")
     private void onError( Exception e ) {
         String message;
 
@@ -124,6 +128,7 @@ class EndpointTCP implements Endpoint {
         this.connection.onMessage( message );
     }
 
+    @ObjectiveCName("send:")
     public void send(String message) {
         try {
             this.out.write( message, 0, message.length() );

--- a/src/main/java/io/deepstream/Event.java
+++ b/src/main/java/io/deepstream/Event.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.EnumSet;
 
 /**
@@ -80,6 +82,7 @@ public enum Event {
      */
     MESSAGE_DENIED;
 
+    @ObjectiveCName("getEvent:")
     static Event getEvent(String event ) {
 
         for( Event s : EnumSet.allOf( Event.class ) ) {

--- a/src/main/java/io/deepstream/List.java
+++ b/src/main/java/io/deepstream/List.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 import java.util.ArrayList;
@@ -23,6 +25,8 @@ public class List {
      * @param recordHandler The recordHandler to get the underlying record
      * @param name The list name
      */
+
+    @ObjectiveCName("init:name:")
     List(RecordHandler recordHandler, String name) {
         this.record = recordHandler.getRecord( name );
 
@@ -73,6 +77,7 @@ public class List {
      * @param recordEventsListener The listener to add
      * @return The list
      */
+    @ObjectiveCName("addRecordEventsListener:")
     public List addRecordEventsListener( RecordEventsListener recordEventsListener ) {
         this.record.addRecordEventsListener( recordEventsListener );
         return this;
@@ -83,6 +88,7 @@ public class List {
      * @param recordEventsListener The listener to remove
      * @return The list
      */
+    @ObjectiveCName("removeRecordEventsListener:")
     public List removeRecordEventsListener(RecordEventsListener recordEventsListener) {
         this.record.removeRecordEventsListener( recordEventsListener );
         return this;
@@ -109,6 +115,7 @@ public class List {
      * @param entries The recordNames to update the list with
      * @return The list
      */
+    @ObjectiveCName("setEntries:")
     public List setEntries(java.util.List<String> entries) {
         this.updateList(entries);
         return this;
@@ -119,6 +126,7 @@ public class List {
      * @param entry The entry to remove from the list
      * @return The list
      */
+    @ObjectiveCName("removeEntry:")
     public List removeEntry( String entry ) {
         Collection entries = this.getEntries();
         while( entries.contains( entry ) ) entries.remove( entry );
@@ -133,6 +141,7 @@ public class List {
      * @param index The index at which the entry should reside at
      * @return The list
      */
+    @ObjectiveCName("removeEntry:index:")
     public List removeEntry( String entry, int index ) {
         java.util.List entries = this.getEntries();
         if( entries.get( index ).equals( entry ) ) {
@@ -148,6 +157,7 @@ public class List {
      * @param entry The entry to add to the list
      * @return The list
      */
+    @ObjectiveCName("addEntry:")
     public List addEntry( String entry ) {
         java.util.List<String> entries = this.getEntries();
         entries.add( entry );
@@ -161,6 +171,7 @@ public class List {
      * @param index The index to add the entry to
      * @return The list
      */
+    @ObjectiveCName("addEntry:index:")
     public List addEntry( String entry, int index ) {
         java.util.List<String> entries = this.getEntries();
         entries.add( index, entry );
@@ -181,6 +192,7 @@ public class List {
      * @param listChangedListener The listener to add
      * @return The list
      */
+    @ObjectiveCName("subscribe:")
     public List subscribe(ListChangedListener listChangedListener) {
         return this.subscribe( listChangedListener, false );
     }
@@ -191,6 +203,7 @@ public class List {
      * @param triggerNow Whether to trigger the listener immediately
      * @return The list
      */
+    @ObjectiveCName("subscribe:triggerNow:")
     public List subscribe(ListChangedListener listChangedListener, boolean triggerNow ) {
         this.listChangedListeners.add( listChangedListener );
 
@@ -212,6 +225,7 @@ public class List {
      * @param listChangedListener The listener to remove
      * @return The list
      */
+    @ObjectiveCName("unsubscribe:")
     public List unsubscribe(ListChangedListener listChangedListener) {
         this.listChangedListeners.remove(listChangedListener);
 
@@ -262,6 +276,7 @@ public class List {
     /**
      * Useful entry point for diffing previous list and new one to get entries added, removed and moved
      */
+    @ObjectiveCName("updateList:")
     private void updateList(Collection entries) {
         Map<String, ArrayList<Integer>> oldStructure = this.beforeChange();
         this.record.set( entries );
@@ -286,6 +301,7 @@ public class List {
      * Compares the structure of the list after a change to its previous structure and notifies
      * any add / move / remove listener. Won't do anything if no listeners are attached.
      */
+    @ObjectiveCName("afterChange:")
     private void afterChange( Map<String,ArrayList<Integer>> oldStructure ) {
         if( oldStructure == null ) {
             return;
@@ -369,6 +385,7 @@ public class List {
         private final Record record;
         private Map<String, ArrayList<Integer>> beforeChange;
 
+        @ObjectiveCName("init:record:")
         RecordListeners( List list, Record record ) {
             this.list = list;
             this.record = record;
@@ -376,6 +393,7 @@ public class List {
         }
 
         @Override
+        @ObjectiveCName("onRecordChanged:data:")
         public void onRecordChanged(String recordName, JsonElement data) {
             for (ListChangedListener listChangeListener : this.list.listChangedListeners) {
                 listChangeListener.onListChanged(this.list.name(), this.list.getEntries());

--- a/src/main/java/io/deepstream/ListChangedListener.java
+++ b/src/main/java/io/deepstream/ListChangedListener.java
@@ -1,13 +1,17 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * List change callback, occurs whenever an the entries change
  */
+
 public interface ListChangedListener {
     /**
      * Notified whenever the entries in the list change
      * @param listName The name of list
      * @param entries A list containing all the record names
      */
+    @ObjectiveCName("onListChanged:entries:")
     void onListChanged(String listName, java.util.List entries);
 }

--- a/src/main/java/io/deepstream/ListEntryChangedListener.java
+++ b/src/main/java/io/deepstream/ListEntryChangedListener.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * List entry callbacks, called whenever an entry is added, removed or moved within the list
  */
@@ -10,6 +12,7 @@ public interface ListEntryChangedListener {
      * @param entry The name of the record that was added to the list
      * @param position The index the recordName was added to
      */
+    @ObjectiveCName("onEntryAdded:entry:position:")
     void onEntryAdded(String listName, String entry, int position);
 
     /**
@@ -18,6 +21,7 @@ public interface ListEntryChangedListener {
      * @param entry The name of the record that was removed to the list
      * @param position The index the recordName was removed from
      */
+    @ObjectiveCName("onEntryRemoved:entry:position:")
     void onEntryRemoved(String listName, String entry, int position);
 
     /**
@@ -26,5 +30,6 @@ public interface ListEntryChangedListener {
      * @param entry The name of the record that was moved within the list
      * @param position The index the recordName was moved to
      */
+    @ObjectiveCName("onEntryMoved:entry:position:")
     void onEntryMoved(String listName, String entry, int position);
 }

--- a/src/main/java/io/deepstream/ListenListener.java
+++ b/src/main/java/io/deepstream/ListenListener.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * An interface that notifies whenever a pattern match has been found or removed when added via {@link RecordHandler#listen(String, ListenListener)}
  * or {@link EventHandler#listen(String, ListenListener)}
@@ -14,6 +16,7 @@ public interface ListenListener {
      * @param subscription The name of the subscription that can be provided
      * @return true if the server responds is willing to accept the request, false to reject
      */
+    @ObjectiveCName("onSubscriptionForPatternAdded:")
     boolean onSubscriptionForPatternAdded( String subscription );
 
     /**
@@ -22,5 +25,6 @@ public interface ListenListener {
      *
      * @param subscription The name of the subscription to stop providing
      */
+    @ObjectiveCName("onSubscriptionForPatternRemoved:")
     void onSubscriptionForPatternRemoved( String subscription );
 }

--- a/src/main/java/io/deepstream/LoginResult.java
+++ b/src/main/java/io/deepstream/LoginResult.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 import java.util.Map;
@@ -19,6 +21,7 @@ public class LoginResult {
      * @param loggedIn true
      * @param userData Optional data that is specific to the user and returned on succesfuly authentication
      */
+    @ObjectiveCName("init:userData:")
     LoginResult(boolean loggedIn, Map userData) {
         this.loggedIn = loggedIn;
         this.errorEvent = null;
@@ -31,6 +34,7 @@ public class LoginResult {
      * @param errorEvent error event
      * @param data Contains data associated to the failed login, such as the reason
      */
+    @ObjectiveCName("init:errorEvent:data:")
     LoginResult(boolean loggedIn, Event errorEvent, Object data) {
         this.loggedIn = loggedIn;
         this.errorEvent = errorEvent;

--- a/src/main/java/io/deepstream/Message.java
+++ b/src/main/java/io/deepstream/Message.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * Message is the internal representation of a message that is sent to received from a deepstream
  * server
@@ -16,6 +18,7 @@ class Message {
      * @param action The message action
      * @param data The message data, as an array
      */
+    @ObjectiveCName("init:topic:action:data:")
     Message( String raw, Topic topic, Actions action, String[] data ) {
         this.raw = raw;
         this.topic = topic;

--- a/src/main/java/io/deepstream/MessageBuilder.java
+++ b/src/main/java/io/deepstream/MessageBuilder.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -12,10 +14,12 @@ class MessageBuilder {
     static private final String MPS = Character.toString( '\u001f' );
     static private final String MS = Character.toString( '\u001e' );
 
+    @ObjectiveCName("getMsg:action:name:data:")
     public static String getMsg( Topic topic, Actions action, String name, String data ) {
         return topic.toString() + MPS + action.toString() + MPS + name + MPS +  data + MS;
     }
 
+    @ObjectiveCName("getMsg:action:data:")
     public static String getMsg( Topic topic, Actions action, String data ) {
         return topic.toString() + MPS + action.toString() + MPS +  data + MS;
     }
@@ -24,6 +28,7 @@ class MessageBuilder {
         return topic.toString() + MPS + action.toString() + MPS + join( data) + MS;
     }
 
+    @ObjectiveCName("getMsg:action:")
     public static String getMsg( Topic topic, Actions action ) {
         return topic.toString() + MPS + action.toString() + MS;
     }
@@ -63,6 +68,7 @@ class MessageBuilder {
      * @param list A list of messages
      * @return A string representation of messages joined together
      */
+    @ObjectiveCName("join:")
     private static String join(String[] list) {
 
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/io/deepstream/MessageParser.java
+++ b/src/main/java/io/deepstream/MessageParser.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
@@ -22,6 +24,7 @@ class MessageParser {
      * and returns an array of parsed message objects
      * or null for invalid messages
      */
+    @ObjectiveCName("parse:client:")
     static List<Message> parse( String message, DeepstreamClientAbstract client ) {
         List<Message> messages = new ArrayList<>();
         String[] rawMessages = message.split( MS );
@@ -42,6 +45,7 @@ class MessageParser {
      * @param client The deepstream client to notify if errors occur
      * @return The {@link Message} object that represents the message string
      */
+    @ObjectiveCName("parseMessage:client:")
     static Message parseMessage( String message, DeepstreamClientAbstract client ) {
         String[] parts = message.split( MPS );
 
@@ -71,6 +75,7 @@ class MessageParser {
      * @param client The deepstream client to notify if errors occur
      * @return The object the value represented
      */
+    @ObjectiveCName("convertTyped:client:")
     static Object convertTyped( String value, DeepstreamClientAbstract client ) {
 
         char type = value.charAt(0);
@@ -101,6 +106,7 @@ class MessageParser {
         return null;
     }
 
+    @ObjectiveCName("parseObject:")
     static Object parseObject(String value) {
         return new Gson().fromJson( value, JsonElement.class );
     }

--- a/src/main/java/io/deepstream/Record.java
+++ b/src/main/java/io/deepstream/Record.java
@@ -5,6 +5,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.*;
 import java.util.List;
 
@@ -45,6 +47,7 @@ public class Record {
      * @param deepstreamConfig Deepstream deepstreamConfig
      * @param client deepstream.io client
      */
+    @ObjectiveCName("init:recordOptions:connection:deepstreamConfig:client:")
     Record(String name, Map recordOptions, IConnection connection, DeepstreamConfig deepstreamConfig, DeepstreamClientAbstract client) {
         this.ackTimeoutRegistry = client.getAckTimeoutRegistry();
         this.name = name;
@@ -127,6 +130,7 @@ public class Record {
      * @param recordEventsListener The listener to add
      * @return The record
      */
+    @ObjectiveCName("addRecordEventsListener:")
     public Record addRecordEventsListener(RecordEventsListener recordEventsListener) {
         this.recordEventsListeners.add( recordEventsListener );
         return this;
@@ -137,6 +141,7 @@ public class Record {
      * @param recordEventsListener The listener to remove
      * @return The record
      */
+    @ObjectiveCName("removeRecordEventsListener:")
     public Record removeRecordEventsListener(RecordEventsListener recordEventsListener) {
         this.recordEventsListeners.remove( recordEventsListener );
         return this;
@@ -147,6 +152,7 @@ public class Record {
      * @param mergeStrategy The name of the built in merge strategy to use
      * @return The record
      */
+    @ObjectiveCName("setMergeStrategy:")
     public Record setMergeStrategy(MergeStrategy mergeStrategy) {
         this.mergeStrategy = RecordMergeStrategies.INSTANCE.getMergeStrategy( mergeStrategy );
         return this;
@@ -157,6 +163,7 @@ public class Record {
      * @param mergeStrategy The custom merge strategy to use
      * @return The record
      */
+    @ObjectiveCName("setMergeStrategyWithRecordMergeStrategy:")
     public Record setMergeStrategy(RecordMergeStrategy mergeStrategy) {
         this.mergeStrategy = mergeStrategy;
         return this;
@@ -187,6 +194,7 @@ public class Record {
      *
      * @return The record data as a JsonElement
      */
+    @ObjectiveCName("get:")
     public JsonElement get( String path ) {
         return deepCopy( this.path.get( path ) );
     }
@@ -210,7 +218,8 @@ public class Record {
      * such as {@link Map}. Since this is a root the object should also not be a primitive.
      *
      * @see Record#set(String, Object)
-     */
+     */ 
+    @ObjectiveCName("set:")
     public Record set( Object value ) throws DeepstreamRecordDestroyedException {
         return this.set( null, value, false );
     }
@@ -229,6 +238,7 @@ public class Record {
      * @return The record
      * @throws DeepstreamRecordDestroyedException Thrown if the record has been destroyed and can't perform more actions
      */
+    @ObjectiveCName("set:value:")
     public Record set(String path, Object value ) throws DeepstreamRecordDestroyedException {
         return this.set( path, value, false );
     }
@@ -237,6 +247,7 @@ public class Record {
      * Notifies the user whenever anything under the path provided has changed.
      * @see Record#subscribe(String, RecordPathChangedCallback, boolean)
      */
+    @ObjectiveCName("subscribe:recordPathChangedCallback:")
     public Record subscribe(String path, RecordPathChangedCallback recordPathChangedCallback ) throws DeepstreamRecordDestroyedException {
         return subscribe( path, recordPathChangedCallback, false );
     }
@@ -254,6 +265,7 @@ public class Record {
      * @return The record
      * @throws DeepstreamRecordDestroyedException Thrown if the record has been destroyed and can't perform more actions
      */
+    @ObjectiveCName("subscribe:recordPathChangedCallback:triggerNow:")
     public Record subscribe( String path, RecordPathChangedCallback recordPathChangedCallback, boolean triggerNow ) throws DeepstreamRecordDestroyedException {
         throwExceptionIfDestroyed( "subscribe" );
 
@@ -270,6 +282,7 @@ public class Record {
      * Notifies the user whenever anything inside the Record has changed.
      * @see Record#subscribe(RecordChangedCallback, boolean)
      */
+    @ObjectiveCName("subscribe:")
     public Record subscribe( RecordChangedCallback recordChangedCallback ) throws DeepstreamRecordDestroyedException {
         return subscribe( recordChangedCallback, false );
     }
@@ -279,6 +292,7 @@ public class Record {
      *  @param recordChangedCallback The callback for whenever anything within the record changes
      *  @param triggerNow Whether to call the callback immediately with the current value
      */
+    @ObjectiveCName("subscribe:triggerNow:")
     public Record subscribe( RecordChangedCallback recordChangedCallback, boolean triggerNow ) throws DeepstreamRecordDestroyedException {
         throwExceptionIfDestroyed( "subscribe" );
 
@@ -298,6 +312,7 @@ public class Record {
      * @throws DeepstreamRecordDestroyedException Thrown if the record has been destroyed and can't perform more actions
      * @return The record
      */
+    @ObjectiveCName("unsubscribe:")
     public Record unsubscribe( RecordChangedCallback recordChangedCallback ) throws DeepstreamRecordDestroyedException {
         throwExceptionIfDestroyed( "unsubscribe" );
         this.subscribers.off( ALL_EVENT, recordChangedCallback );
@@ -311,6 +326,7 @@ public class Record {
      * @throws DeepstreamRecordDestroyedException Thrown if the record has been destroyed and can't perform more actions
      * @return The record
      */
+    @ObjectiveCName("unsubscribe:recordPathChangedCallback:")
     public Record unsubscribe( String path, RecordPathChangedCallback recordPathChangedCallback ) throws DeepstreamRecordDestroyedException {
         throwExceptionIfDestroyed( "unsubscribe" );
         this.subscribers.off( path, recordPathChangedCallback );
@@ -381,6 +397,7 @@ public class Record {
      * @param recordReadyListener The recordReadyListener that will be triggered only **once**
      * @return The record
      */
+    @ObjectiveCName("whenReady:")
     Record whenReady(RecordReadyListener recordReadyListener) {
         if( this.isReady ) {
             recordReadyListener.onRecordReady( this.name, this );
@@ -394,6 +411,7 @@ public class Record {
      * Invoked when a message is received from {@link RecordHandler#handle(Message)}
      * @param message The message received from the server
      */
+    @ObjectiveCName("onMessage:")
     void onMessage(Message message) {
         if( message.action == Actions.ACK ) {
             processAckMessage( message );
@@ -414,10 +432,12 @@ public class Record {
      * This gives us a handle to before and after a record is updated remotely. This is currently used by {@link io.deepstream.List}
      * @param recordRemoteUpdateHandler The listener to notify before and after an update is applied
      */
+    @ObjectiveCName("setRecordRemoteUpdateHandler:")
     void setRecordRemoteUpdateHandler(RecordRemoteUpdateHandler recordRemoteUpdateHandler) {
         this.recordRemoteUpdateHandler = recordRemoteUpdateHandler;
     }
 
+    // @ObjectiveCName("updateHasProvider:")
     private void updateHasProvider(Message message) {
         this.hasProvider = (boolean) MessageParser.convertTyped(message.data[1], this.client);
         for (RecordEventsListener recordEventsListener : this.recordEventsListeners) {
@@ -428,6 +448,7 @@ public class Record {
     /**
      * Apply the message received on the server on the record
      */
+    @ObjectiveCName("applyUpdate:")
     private void applyUpdate(Message message) {
         int newVersion = Integer.parseInt(message.data[1]);
 
@@ -480,6 +501,7 @@ public class Record {
      * @param remoteVersion The remote version number
      * @param remoteData The remote object data
      */
+    @ObjectiveCName("recoverRecord:remoteData:")
     private void recoverRecord(int remoteVersion, JsonElement remoteData) {
         try {
             JsonElement mergedData = this.mergeStrategy.merge( this, remoteData, remoteVersion );
@@ -540,6 +562,7 @@ public class Record {
      *
      * @param oldValues The previous paths and values
      */
+    // @ObjectiveCName("completeChange:")
     private void completeChange(Map<String,JsonElement> oldValues) {
         List<Object> listeners;
 
@@ -576,6 +599,7 @@ public class Record {
      * @param method The method to call
      * @throws DeepstreamRecordDestroyedException Thrown if the record has been destroyed and can't perform more actions
      */
+    // @ObjectiveCName("throwExceptionIfDestroyed:")
     private void throwExceptionIfDestroyed(String method) throws DeepstreamRecordDestroyedException {
         if( this.isDestroyed ) {
             throw new DeepstreamRecordDestroyedException( method );
@@ -585,6 +609,7 @@ public class Record {
     /**
      * @param message The ack {@link Message}
      */
+    @ObjectiveCName("processAckMessage:")
     private void processAckMessage(Message message) {
         Actions action = Actions.getAction( message.data[ 0 ] );
         this.ackTimeoutRegistry.clear( message );
@@ -607,6 +632,7 @@ public class Record {
      * Callback for incoming read messages
      * @param message The read {@link Message}
      */
+    @ObjectiveCName("onRead:")
     private void onRead( Message message ) {
         ackTimeoutRegistry.clear( message );
 
@@ -646,6 +672,7 @@ public class Record {
      * @param key The key to update if a patch
      * @param value The value to update the record with
      */
+    @ObjectiveCName("sendUpdate:value:")
     private void sendUpdate( String key, Object value ) {
         if( key == null || key.equals("") ) {
             this.connection.sendMsg( Topic.RECORD, Actions.UPDATE, new String[] {
@@ -678,6 +705,7 @@ public class Record {
     /**
      * Generate a deep copy of the object to prevent user to modify record data directly
      */
+    @ObjectiveCName("deepCopy:")
     private JsonElement deepCopy(JsonElement element) {
         try {
             return gson.fromJson(gson.toJson(element, JsonElement.class), JsonElement.class);
@@ -698,6 +726,7 @@ public class Record {
      * This forces an update, which is useful when trying to reconcile a merge conflict when the merge is the same
      * but the version number isn't.
      */
+    @ObjectiveCName("set:value:force:")
     private Record set(String path, Object value, boolean force ) throws DeepstreamRecordDestroyedException {
         throwExceptionIfDestroyed( "set" );
 
@@ -725,6 +754,7 @@ public class Record {
     /**
      * Add a destroy pending listener, used by the RecordHandler and potentially other internal stores
      */
+    @ObjectiveCName("addRecordDestroyPendingListener:")
     void addRecordDestroyPendingListener(RecordDestroyPendingListener recordDestroyPendingListener) {
         this.recordDestroyPendingListeners.add( recordDestroyPendingListener );
     }

--- a/src/main/java/io/deepstream/Record.java
+++ b/src/main/java/io/deepstream/Record.java
@@ -437,7 +437,7 @@ public class Record {
         this.recordRemoteUpdateHandler = recordRemoteUpdateHandler;
     }
 
-    // @ObjectiveCName("updateHasProvider:")
+    @ObjectiveCName("updateHasProvider:")
     private void updateHasProvider(Message message) {
         this.hasProvider = (boolean) MessageParser.convertTyped(message.data[1], this.client);
         for (RecordEventsListener recordEventsListener : this.recordEventsListeners) {

--- a/src/main/java/io/deepstream/RecordChangedCallback.java
+++ b/src/main/java/io/deepstream/RecordChangedCallback.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 /**
@@ -12,5 +14,6 @@ public interface RecordChangedCallback {
      * @param recordName The name of the record change
      * @param data The entire data as a {@link JsonElement}, can be retrieved via {@link JsonElement#getAsJsonObject()}
      */
+    @ObjectiveCName("onRecordChanged:data:")
     void onRecordChanged(String recordName, JsonElement data );
 }

--- a/src/main/java/io/deepstream/RecordEventsListener.java
+++ b/src/main/java/io/deepstream/RecordEventsListener.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * Record state changed listener, used to be notified whenever the record state has occurred
  */
@@ -13,6 +15,7 @@ public interface RecordEventsListener {
      * @param errorMessage An error message in english, describing the issue. Do not use this message other than for
      *                     logging! All checks should be against errorType
      */
+    @ObjectiveCName("onError:errorType:errorMessage:")
     void onError(String recordName, Event errorType, String errorMessage);
 
     /**
@@ -21,6 +24,7 @@ public interface RecordEventsListener {
      * @param recordName The name of the record which has gained/lost a provider
      * @param hasProvider true if provider was found, false otherwise
      */
+    @ObjectiveCName("onRecordHasProviderChanged:hasProvider:")
     void onRecordHasProviderChanged(String recordName, boolean hasProvider);
 
     /**
@@ -29,6 +33,7 @@ public interface RecordEventsListener {
      * to continue setting data.
      * @param recordName The name of the deleted record
      */
+    @ObjectiveCName("onRecordDeleted:")
     void onRecordDeleted( String recordName );
 
     /**
@@ -37,5 +42,6 @@ public interface RecordEventsListener {
      * to continue setting data.
      * @param recordName The name of the discarded record
      */
+    @ObjectiveCName("onRecordDiscarded:")
     void onRecordDiscarded(String recordName);
 }

--- a/src/main/java/io/deepstream/RecordHandler.java
+++ b/src/main/java/io/deepstream/RecordHandler.java
@@ -1,5 +1,6 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
 
 import com.google.gson.JsonElement;
 
@@ -32,6 +33,7 @@ public class RecordHandler {
      * @param connection The connection
      * @param client The deepstream client
      */
+    @ObjectiveCName("init:connection:client:")
     RecordHandler(DeepstreamConfig deepstreamConfig, IConnection connection, DeepstreamClientAbstract client) {
         this.deepstreamConfig = deepstreamConfig;
         this.connection = connection;
@@ -52,6 +54,7 @@ public class RecordHandler {
      * @param name The name of the record to get
      * @return Record The record
      */
+    @ObjectiveCName("getRecord:")
     public Record getRecord( String name ) {
         Record record = records.get( name );
         if( record == null ) {
@@ -90,6 +93,7 @@ public class RecordHandler {
      * @param name The name of the list to retrieve
      * @return List The List
      */
+    @ObjectiveCName("getList:")
     public List getList( String name ) {
         List list = lists.get( name );
         if( list == null ) {
@@ -126,6 +130,7 @@ public class RecordHandler {
      * @param pattern The pattern to match all records your interested in
      * @param listenCallback The listen callback when a match has been found or removed.
      */
+    @ObjectiveCName("listen:listenCallback:")
     public void listen( String pattern, ListenListener listenCallback ) {
         if( listeners.containsKey( pattern ) ) {
             client.onError( Topic.RECORD, Event.LISTENER_EXISTS, pattern );
@@ -143,6 +148,7 @@ public class RecordHandler {
      *
      * @param pattern The pattern to stop listening to
      */
+    @ObjectiveCName("unlisten:")
     public void unlisten( String pattern ) {
         UtilListener listener = listeners.get( pattern );
         if( listener != null ) {
@@ -160,6 +166,7 @@ public class RecordHandler {
      *
      * @param name The name of the record which state to retrieve
      */
+    @ObjectiveCName("snapshot:")
     public JsonElement snapshot(String name) throws DeepstreamError {
         final JsonElement[] data = new JsonElement[1];
         final DeepstreamError[] deepstreamException = new DeepstreamError[1];
@@ -173,12 +180,14 @@ public class RecordHandler {
 
             snapshotRegistry.request(name, new UtilSingleNotifier.UtilSingleNotifierCallback() {
                 @Override
+                @ObjectiveCName("onSingleNotifierError:error:")
                 public void onSingleNotifierError(String name, DeepstreamError error) {
                     deepstreamException[0] = error;
                     snapshotLatch.countDown();
                 }
 
                 @Override
+                @ObjectiveCName("onSingleNotifierResponse:recordData:")
                 public void onSingleNotifierResponse(String name, Object recordData) {
                     data[0] = (JsonElement) recordData;
                     snapshotLatch.countDown();
@@ -207,6 +216,7 @@ public class RecordHandler {
      *
      * @param name The name of the record to check
      */
+    @ObjectiveCName("has:")
     public boolean has(String name) throws DeepstreamError {
         final DeepstreamError[] deepstreamException = new DeepstreamError[1];
         final boolean[] hasRecord = new boolean[1];
@@ -219,12 +229,14 @@ public class RecordHandler {
 
             hasRegistry.request(name, new UtilSingleNotifier.UtilSingleNotifierCallback() {
                 @Override
+                @ObjectiveCName("onSingleNotifierError:error:")
                 public void onSingleNotifierError(String name, DeepstreamError error) {
                     deepstreamException[0] = error;
                     hasLatch.countDown();
                 }
 
                 @Override
+                @ObjectiveCName("onSingleNotifierResponse:data:")
                 public void onSingleNotifierResponse(String name, Object data) {
                     hasRecord[0] = (boolean) data;
                     hasLatch.countDown();
@@ -249,6 +261,7 @@ public class RecordHandler {
     /**
      * Will be called by the client for incoming messages on the RECORD topic
      */
+    @ObjectiveCName("handle:")
     protected void handle( Message message ) {
         Record record;
         boolean processed = false;
@@ -320,6 +333,7 @@ public class RecordHandler {
      * A (presumably unsolvable) problem remains when a client deletes a record in the exact moment
      * between another clients creation and read message for the same record
      */
+    @ObjectiveCName("isDiscardAck:")
     private boolean isDiscardAck( Message message ) {
         Event event = Event.getEvent( message.data[ 0 ] );
         if( event == Event.MESSAGE_DENIED && Actions.getAction(message.data[ 2 ] ) == Actions.DELETE ) {
@@ -331,6 +345,7 @@ public class RecordHandler {
         return action == Actions.DELETE || action == Actions.UNSUBSCRIBE;
     }
 
+    @ObjectiveCName("isUnhandledError:")
     private Boolean isUnhandledError(Message message) {
         if( message.action != Actions.ERROR ) {
             return false;
@@ -353,11 +368,13 @@ public class RecordHandler {
         }
 
         @Override
+        @ObjectiveCName("onError:errorType:errorMessage:")
         public void onError(String recordName, Event errorType, String errorMessage) {
             client.onError(Topic.RECORD, errorType, recordName + ":" + errorMessage);
         }
 
         @Override
+        @ObjectiveCName("onRecordHasProviderChanged:hasProvider:")
         public void onRecordHasProviderChanged(String recordName, boolean hasProvider) {
 
         }
@@ -369,6 +386,7 @@ public class RecordHandler {
          * removed from the cache straight awy and will only listen for one last ACK message
          */
         @Override
+        @ObjectiveCName("onDestroyPending:")
         public void onDestroyPending(final String recordName) {
             //TODO:
             /*destroyEventEmitter.on( "destroy_ack_" + recordName, new Emitter.Listener() {
@@ -382,11 +400,13 @@ public class RecordHandler {
         }
 
         @Override
+        @ObjectiveCName("onRecordDeleted:")
         public void onRecordDeleted(String recordName) {
             onRecordDiscarded(recordName);
         }
 
         @Override
+        @ObjectiveCName("onRecordDiscarded:")
         public void onRecordDiscarded(String recordName) {
             records.remove(recordName);
             lists.remove(recordName);

--- a/src/main/java/io/deepstream/RecordMergeStrategies.java
+++ b/src/main/java/io/deepstream/RecordMergeStrategies.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 import java.util.HashMap;
@@ -33,6 +35,7 @@ class RecordMergeStrategies {
      * @param mergeStrategy The merge strategy enum defined in {@link MergeStrategy}
      * @return The {@link RecordMergeStrategy}
      */
+    @ObjectiveCName("getMergeStrategy:")
     public RecordMergeStrategy getMergeStrategy(MergeStrategy mergeStrategy) {
         return strategies.get(mergeStrategy);
     }

--- a/src/main/java/io/deepstream/RecordMergeStrategy.java
+++ b/src/main/java/io/deepstream/RecordMergeStrategy.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 /**
@@ -24,5 +26,6 @@ public interface RecordMergeStrategy {
      * @throws RecordMergeStrategyException Thrown if a merge conflict occurs, mainly if any dependent logic doesn't work.
      *
      */
+    @ObjectiveCName("merge:remoteValue:remoteVersion:")
     JsonElement merge(Record record, JsonElement remoteValue, int remoteVersion ) throws RecordMergeStrategyException;
 }

--- a/src/main/java/io/deepstream/RecordMergeStrategyException.java
+++ b/src/main/java/io/deepstream/RecordMergeStrategyException.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 /**
@@ -41,6 +43,7 @@ public class RecordMergeStrategyException extends RuntimeException {
      * Use when you don't need a reference to the actual conflicting data
      * @see RecordMergeStrategyException#RecordMergeStrategyException(int, JsonElement, int, JsonElement, String)
      */
+    @ObjectiveCName("init:")
     public RecordMergeStrategyException( String error ) {
         this(-1, null, -1, null, error);
     }
@@ -53,6 +56,7 @@ public class RecordMergeStrategyException extends RuntimeException {
      * @param remoteData The remote data during the merge
      * @param error An error message describing the issue
      */
+    @ObjectiveCName("init:oldData:remoteVersion:remoteData:error:")
     public RecordMergeStrategyException(int localVersion, JsonElement oldData, int remoteVersion, JsonElement remoteData, String error ) {
         this.localVersion = localVersion;
         this.oldData = oldData;

--- a/src/main/java/io/deepstream/RecordPathChangedCallback.java
+++ b/src/main/java/io/deepstream/RecordPathChangedCallback.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonElement;
 
 /**
@@ -13,5 +15,6 @@ public interface RecordPathChangedCallback {
      * @param path The path subscribed to
      * @param data The data under the path as an Object
      */
+    @ObjectiveCName("onRecordPathChanged:path:data:")
     void onRecordPathChanged(String recordName, String path, JsonElement data);
 }

--- a/src/main/java/io/deepstream/Rpc.java
+++ b/src/main/java/io/deepstream/Rpc.java
@@ -1,5 +1,6 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
 
 class Rpc implements UtilTimeoutListener {
 
@@ -21,6 +22,7 @@ class Rpc implements UtilTimeoutListener {
      * @param uid The unique RPC identifier
      * @param callback The callback when an RPC has been completed
      */
+    @ObjectiveCName("init:client:rpcName:uid:callback:")
     Rpc(DeepstreamConfig deepstreamConfig, DeepstreamClientAbstract client, String rpcName, String uid, RpcHandler.RpcResponseCallback callback) {
         this.deepstreamConfig = deepstreamConfig;
         this.client = client;
@@ -44,6 +46,7 @@ class Rpc implements UtilTimeoutListener {
      * @param rpcName The rpc name
      * @param data The data received from the server
      */
+    @ObjectiveCName("respond:data:")
     void respond( String rpcName, String data ) {
         Object convertedData = MessageParser.convertTyped( data, this.client );
         this.callback.onRpcSuccess(rpcName, convertedData);
@@ -58,12 +61,14 @@ class Rpc implements UtilTimeoutListener {
      * @param rpcName The rpc name
      * @param err The errorMessage received from the server
      */
+    @ObjectiveCName("error:err:")
     void error( String rpcName, String err ) {
         this.callback.onRpcError(rpcName, err);
         this.clearTimeouts();
     }
 
     @Override
+    @ObjectiveCName("onTimeout:action:event:name:")
     public void onTimeout(Topic topic, Actions action, Event event, String name) {
         this.error( this.rpcName, event.toString() );
     }

--- a/src/main/java/io/deepstream/RpcHandler.java
+++ b/src/main/java/io/deepstream/RpcHandler.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -26,6 +28,7 @@ public class RpcHandler {
      * @param connection The connection to deepstream
      * @param client The deepstream client
      */
+    @ObjectiveCName("init:connection:client:")
     RpcHandler(DeepstreamConfig deepstreamConfig, final IConnection connection, DeepstreamClientAbstract client) {
         this.deepstreamConfig = deepstreamConfig;
         this.connection = connection;
@@ -56,6 +59,7 @@ public class RpcHandler {
      * @param rpcName The rpcName of the RPC to provide
      * @param rpcRequestedListener The listener to invoke when requests are received
      */
+    @ObjectiveCName("provide:rpcRequestedListener:")
     public void provide( String rpcName, RpcRequestedListener rpcRequestedListener ) {
         if( this.providers.containsKey( rpcName ) ) {
             throw new DeepstreamException( "RPC " + rpcName + " already registered" );
@@ -71,6 +75,7 @@ public class RpcHandler {
      * Unregister a {@link RpcRequestedListener} registered via Rpc{@link #provide(String, RpcRequestedListener)}
      * @param rpcName The rpcName of the RPC to stop providing
      */
+    @ObjectiveCName("unprovide:")
     public void unprovide( String rpcName ) {
         if( this.providers.containsKey( rpcName ) ) {
             this.providers.remove( rpcName );
@@ -87,6 +92,7 @@ public class RpcHandler {
      * @param data Serializable data that will be passed to the provider
      * @return Find out if the rpc succeeded via {@link RpcResult#success()} and associated data via {@link RpcResult#getData()}
      */
+    @ObjectiveCName("make:data:")
     public RpcResult make(String rpcName, Object data) {
         final RpcResult[] rpcResponse = new RpcResult[1];
         final CountDownLatch responseLatch = new CountDownLatch(1);
@@ -126,6 +132,7 @@ public class RpcHandler {
      * from the message distributor
      * @param message The message recieved from the server
      */
+    @ObjectiveCName("handle:")
     void handle( Message message ) {
         String rpcName;
         String correlationId;
@@ -181,6 +188,7 @@ public class RpcHandler {
      * Retrieves a RPC instance for a correlationId or throws an error
      * if it can't be found (which should never happen)
      */
+    @ObjectiveCName("getRpc:raw:")
     private Rpc getRpc(String correlationId, String raw) {
         Rpc rpc = this.rpcs.get( correlationId );
 
@@ -197,6 +205,7 @@ public class RpcHandler {
      * is present (which shouldn't really happen, but might be the result of a race condition
      * if this client sends a unprovide message whilst an incoming request is already in flight)
      */
+    @ObjectiveCName("respondToRpc:")
     private void respondToRpc( Message message ) {
         String rpcName = message.data[ 0 ];
         String correlationId = message.data[ 1 ];
@@ -219,6 +228,7 @@ public class RpcHandler {
     /**
      * Send an unsubscribe or subscribe event if the connection is open
      */
+    @ObjectiveCName("sendRPCSubscribe:")
     private void sendRPCSubscribe(String rpcName) {
         if( this.client.getConnectionState() == ConnectionState.OPEN ) {
             this.ackTimeoutRegistry.add(Topic.RPC, Actions.SUBSCRIBE, rpcName, deepstreamConfig.getSubscriptionTimeout());
@@ -237,6 +247,7 @@ public class RpcHandler {
          * @param rpcName The rpc name
          * @param data    The result data from the rpc
          */
+        @ObjectiveCName("onRpcSuccess:data:")
         void onRpcSuccess(String rpcName, Object data);
 
         /**
@@ -245,6 +256,7 @@ public class RpcHandler {
          *
          * @param rpcName The rpc name
          */
+        @ObjectiveCName("onRpcError:error:")
         void onRpcError(String rpcName, Object error);
     }
 }

--- a/src/main/java/io/deepstream/RpcRequestedListener.java
+++ b/src/main/java/io/deepstream/RpcRequestedListener.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * Listener for any rpc requests recieved from the server
  */
@@ -11,5 +13,6 @@ public interface RpcRequestedListener {
      * @param data The data the request was made with
      * @param response The {@link RpcResponse} to respond to the request with
      */
+    @ObjectiveCName("onRPCRequested:data:response:")
     void onRPCRequested(String rpcName, Object data, RpcResponse response);
 }

--- a/src/main/java/io/deepstream/RpcResponse.java
+++ b/src/main/java/io/deepstream/RpcResponse.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * This object provides a number of methods that allow a rpc provider
  * to respond to a request
@@ -21,6 +23,7 @@ public class RpcResponse {
      * @param name          the name of the rpc
      * @param correlationId the correlationId for the RPC
      */
+    @ObjectiveCName("init:name:correlationId:")
     RpcResponse(IConnection connection, String name, String correlationId) {
         this.connection = connection;
         this.name = name;
@@ -65,6 +68,7 @@ public class RpcResponse {
      *
      * @param data the data send by the provider. Has to be JsonSerializable
      */
+    @ObjectiveCName("send:")
     public void send(Object data) {
         if (this.isComplete) {
             throw new DeepstreamException("Rpc " + this.name + " already completed");
@@ -82,6 +86,7 @@ public class RpcResponse {
      *
      * @param errorMsg the message used to describe the error that occured
      */
+    @ObjectiveCName("error:")
     public void error(String errorMsg) {
         this.isComplete = true;
         this.isAcknowledged = true;

--- a/src/main/java/io/deepstream/RpcResult.java
+++ b/src/main/java/io/deepstream/RpcResult.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * RpcResult provides you access to the response state
  * of a rpc request called via {@link RpcHandler#make(String, Object)}
@@ -15,6 +17,7 @@ public class RpcResult {
      * @param success true the rpc completed succesfully
      * @param data the data returned by the request
      */
+    @ObjectiveCName("init:data:")
     RpcResult(boolean success, Object data) {
         this.success = success;
         this.data = data;

--- a/src/main/java/io/deepstream/Topic.java
+++ b/src/main/java/io/deepstream/Topic.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,10 +46,12 @@ public enum Topic {
 
     private String topic;
 
+    @ObjectiveCName("init:")
     Topic( String topic ) {
         this.topic = topic;
     }
 
+    @ObjectiveCName("getTopic:")
     static Topic getTopic( String topic ) {
         return lookup.get( topic );
     }

--- a/src/main/java/io/deepstream/Types.java
+++ b/src/main/java/io/deepstream/Types.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,10 +53,12 @@ enum Types {
 
     private String type;
 
+    @ObjectiveCName("init:")
     Types( String type ) {
         this.type = type;
     }
 
+    @ObjectiveCName("getType:")
     static Types getType( char type ) {
         return lookup.get( type + "" );
     }

--- a/src/main/java/io/deepstream/UtilAckTimeoutRegistry.java
+++ b/src/main/java/io/deepstream/UtilAckTimeoutRegistry.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.Map;
 import java.util.concurrent.*;
 
@@ -17,6 +19,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
      *
      * @param client The client it sends errors to
      */
+    @ObjectiveCName("init:")
     UtilAckTimeoutRegistry(DeepstreamClientAbstract client) {
         this.client = client;
         this.register = new ConcurrentHashMap<>();
@@ -32,6 +35,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
      *
      * @param message The message received to remove the ack timer for
      */
+    @ObjectiveCName("clear:")
     void clear( Message message ) {
         Actions action;
         String name;
@@ -51,8 +55,11 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
 
     /**
      * Clears the ack timeout for a message.
-
+     *
+     * @param name The name to be added to the register
+     * @param action The action to be added to the register
      */
+    @ObjectiveCName("clear:action:name:")
     void clear(  Topic topic, Actions action, String name ) {
         String uniqueName = this.getUniqueName( topic, action, name );
         this.clear( uniqueName );
@@ -65,6 +72,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
      * @param name The name to be added to the register
      * @param action The action to be added to the register
      */
+    @ObjectiveCName("add:action:name:event:timeout:")
     void add( Topic topic, Actions action, String name, Event event, int timeout ) {
         this.add( topic, action, name, event, this, timeout );
     }
@@ -76,6 +84,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
      * @param name The name to be added to the register
      * @param action The action to be added to the register
      */
+    @ObjectiveCName("add:action:name:timeout:")
     void add( Topic topic, Actions action, String name, int timeout ) {
         this.add( topic, action, name, Event.ACK_TIMEOUT, this, timeout );
     }
@@ -87,6 +96,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
      * @param name The name to be added to the register
      * @param action The action to be added to the register
      */
+    @ObjectiveCName("add:action:name:event:timeoutListener:timeout:")
     void add(Topic topic, Actions action, String name, Event event, UtilTimeoutListener timeoutListener, int timeout ) {
         String uniqueName = this.getUniqueName( topic, action, name );
         this.clear( uniqueName );
@@ -95,6 +105,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
     }
 
     @Override
+    @ObjectiveCName("connectionStateChanged:")
     public void connectionStateChanged(ConnectionState connectionState) {
         if( connectionState == ConnectionState.OPEN ) {
             scheduleAcks();
@@ -107,6 +118,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
      *
      * @param uniqueName The name of the message ( and possible action ) to remove the timeout for
      */
+    @ObjectiveCName("clear:")
     private boolean clear( String uniqueName ) {
         ScheduledFuture scheduledFuture = register.get( uniqueName );
         if( scheduledFuture != null ) {
@@ -122,6 +134,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
      * Adds the uniqueName to the register. Only schedules the timer if
      * the connection state is OPEN, otherwise it adds to the queue of waiting acks.
      */
+    @ObjectiveCName("addToRegister:action:name:event:timeoutListener:timeoutDuration:")
     private void addToRegister(Topic topic, Actions action, String name, Event event, UtilTimeoutListener timeoutListener, int timeoutDuration ) {
         AckTimeout task = new AckTimeout( topic, action, name, event, timeoutListener, timeoutDuration );
 
@@ -136,6 +149,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
     }
 
     @Override
+    @ObjectiveCName("onTimeout:action:event:name:")
     public void onTimeout(Topic topic, Actions action, Event event, String name ) {
         String uniqueName = this.getUniqueName( topic, action, name );
         this.register.remove( uniqueName );
@@ -157,6 +171,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
         }
     }
 
+    @ObjectiveCName("getUniqueName:action:name:")
     private String getUniqueName( Topic topic, Actions action, String name ) {
         return topic.toString() + action.toString() + name;
     }
@@ -169,6 +184,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
         private final Event event;
         private final int timeout;
 
+        @ObjectiveCName("init:action:name:event:timeoutListener:timeout:")
         AckTimeout(Topic topic, Actions action, String name, Event event, UtilTimeoutListener timeoutListener, int timeout ) {
             this.topic = topic;
             this.action = action;

--- a/src/main/java/io/deepstream/UtilAckTimeoutRegistry.java
+++ b/src/main/java/io/deepstream/UtilAckTimeoutRegistry.java
@@ -118,7 +118,7 @@ class UtilAckTimeoutRegistry implements ConnectionStateListener, UtilTimeoutList
      *
      * @param uniqueName The name of the message ( and possible action ) to remove the timeout for
      */
-    @ObjectiveCName("clear:")
+    @ObjectiveCName("clearWithUniqueName:")
     private boolean clear( String uniqueName ) {
         ScheduledFuture scheduledFuture = register.get( uniqueName );
         if( scheduledFuture != null ) {

--- a/src/main/java/io/deepstream/UtilEmitter.java
+++ b/src/main/java/io/deepstream/UtilEmitter.java
@@ -1,5 +1,6 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -28,6 +29,7 @@ class UtilEmitter {
      * @param fn The listener to invoke
      * @return a reference to this object.
      */
+    @ObjectiveCName("on:fn:")
     public UtilEmitter on(Enum enu, Object fn ) {
         this.on( enu.toString(), fn );
         return this;
@@ -39,6 +41,7 @@ class UtilEmitter {
      * @param fn The listener to invoke
      * @return a reference to this object.
      */
+    @ObjectiveCName("onWithEvent:fn:")
     public UtilEmitter on(String event, Object fn) {
         ConcurrentLinkedQueue<Object> callbacks = this.callbacks.get(event);
         if (callbacks == null) {
@@ -59,6 +62,7 @@ class UtilEmitter {
      * @param fn The listener to invoke
      * @return a reference to this object.
      */
+    @ObjectiveCName("once:fn:")
     public UtilEmitter once(final String event, final Listener fn) {
         this.on(event, new OnceListener(event, fn));
         return this;
@@ -80,6 +84,7 @@ class UtilEmitter {
      * @param event an event name.
      * @return a reference to this object.
      */
+    @ObjectiveCName("off:")
     public UtilEmitter off(String event) {
         this.callbacks.remove(event);
         return this;
@@ -92,6 +97,7 @@ class UtilEmitter {
      * @param fn The listener to invoke
      * @return a reference to this object.
      */
+    @ObjectiveCName("off:fn:")
     public UtilEmitter off(String event, Object fn) {
         ConcurrentLinkedQueue<Object> callbacks = this.callbacks.get(event);
         if (callbacks != null) {
@@ -113,6 +119,7 @@ class UtilEmitter {
      * @param event an event name.
      * @return a reference to this object.
      */
+    @ObjectiveCName("listeners:")
     public List<Object> listeners(String event) {
         ConcurrentLinkedQueue<Object> callbacks = this.callbacks.get(event);
         return callbacks != null ?
@@ -125,6 +132,7 @@ class UtilEmitter {
      * @param event an event name.
      * @return true if a listener exists for that eventname
      */
+    @ObjectiveCName("hasListeners:")
     public boolean hasListeners(String event) {
         ConcurrentLinkedQueue<Object> callbacks = this.callbacks.get(event);
         return callbacks == null || callbacks.isEmpty();
@@ -148,6 +156,7 @@ class UtilEmitter {
     }
 
     interface Listener {
+        @ObjectiveCName("call:")
         void call(Object... args);
     }
 
@@ -156,12 +165,14 @@ class UtilEmitter {
         public final String event;
         public final Listener fn;
 
+        @ObjectiveCName("init:fn:")
         public OnceListener(String event, Listener fn) {
             this.event = event;
             this.fn = fn;
         }
 
         @Override
+        @ObjectiveCName("call:")
         public void call(Object... args) {
             UtilEmitter.this.off(this.event, this);
             this.fn.call(args);

--- a/src/main/java/io/deepstream/UtilJSONPath.java
+++ b/src/main/java/io/deepstream/UtilJSONPath.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
@@ -11,10 +13,12 @@ import java.util.Objects;
 class UtilJSONPath {
     private JsonElement coreElement;
 
+    @ObjectiveCName("init:")
     public UtilJSONPath(JsonElement e){
         this.coreElement = e;
     }
 
+    @ObjectiveCName("iterateThrough:path:value:")
     private static JsonElement iterateThrough (JsonElement element, String path, JsonElement value) {
         String[] st = path.split( "\\." );
         JsonElement parent = null;
@@ -63,6 +67,7 @@ class UtilJSONPath {
         return traverser;
     }
 
+    @ObjectiveCName("updateValue:parent:token:")
     private static void updateValue(JsonElement value, JsonElement parent, String token) {
         if( parent.isJsonObject() ) {
             JsonObject object = (JsonObject) parent;
@@ -79,6 +84,7 @@ class UtilJSONPath {
         }
     }
 
+    @ObjectiveCName("getArrayElement:token:")
     private static JsonElement getArrayElement(JsonElement traverser,
                                                String token) {
 
@@ -94,14 +100,17 @@ class UtilJSONPath {
         }
     }
 
+    @ObjectiveCName("getTokenPrefix:")
     private static String getTokenPrefix(String token) {
         return token.substring( 0, token.indexOf( "[" ) );
     }
 
+    @ObjectiveCName("getIndex:")
     private static String getIndex(String token) {
         return token.substring(token.indexOf("[") + 1, token.indexOf("]")).trim();
     }
 
+    @ObjectiveCName("isArray:")
     private static boolean isArray(String token) {
         boolean isArray = ( token.contains("[") && token.contains("]") && (token.indexOf("[") < token.indexOf("]")));
         try {
@@ -112,6 +121,7 @@ class UtilJSONPath {
         }
     }
 
+    @ObjectiveCName("get:")
     public JsonElement get(String path) {
         if (Objects.equals(path, "") || path == null) {
             return this.coreElement;
@@ -120,6 +130,7 @@ class UtilJSONPath {
         }
     }
 
+    @ObjectiveCName("set:value:")
     public void set(String path, JsonElement value) {
         if (Objects.equals(path, "")) {
             throw new RuntimeException("Setting an entire object must be done via setValue( JsonElement value );");
@@ -134,6 +145,7 @@ class UtilJSONPath {
         return coreElement;
     }
 
+    @ObjectiveCName("setCoreElement:")
     public void setCoreElement(JsonElement coreElement) {
         this.coreElement = coreElement;
     }
@@ -142,6 +154,7 @@ class UtilJSONPath {
         private final JsonArray root;
         private JsonElement coreElement;
 
+        @ObjectiveCName("init:")
         public Array(JsonArray root) {
             this.root = root;
         }

--- a/src/main/java/io/deepstream/UtilListener.java
+++ b/src/main/java/io/deepstream/UtilListener.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -17,6 +19,7 @@ class UtilListener implements UtilResubscribeNotifier.UtilResubscribeListener {
 
     private ExecutorService executorService;
 
+    @ObjectiveCName("init:pattern:listenerCallback:deepstreamConfig:client:connection:")
     public UtilListener(Topic topic, String pattern, ListenListener listenerCallback, DeepstreamConfig deepstreamConfig, DeepstreamClientAbstract client, IConnection connection) {
         this.topic = topic;
         this.pattern = pattern;
@@ -47,6 +50,7 @@ class UtilListener implements UtilResubscribeNotifier.UtilResubscribeListener {
         this.ackTimoutRegistry = null;
     }
 
+    @ObjectiveCName("onMessage:")
     public void onMessage(final Message message) {
         if( message.action.equals( Actions.ACK ) ) {
             this.ackTimoutRegistry.clear( message );
@@ -68,10 +72,12 @@ class UtilListener implements UtilResubscribeNotifier.UtilResubscribeListener {
         this.connection.sendMsg( this.topic, Actions.LISTEN, new String[] { this.pattern } );
     }
 
+    @ObjectiveCName("sendAccept:")
     private void sendAccept(String subscription) {
         this.connection.sendMsg(this.topic, Actions.LISTEN_ACCEPT, new String[]{this.pattern, subscription});
     }
 
+    @ObjectiveCName("sendReject:")
     private void sendReject(String subscription) {
         this.connection.sendMsg(this.topic, Actions.LISTEN_REJECT, new String[]{this.pattern, subscription});
     }

--- a/src/main/java/io/deepstream/UtilResubscribeNotifier.java
+++ b/src/main/java/io/deepstream/UtilResubscribeNotifier.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 /**
  * Makes sure that all functionality is resubscribed on reconnect. Subscription is called
  * when the connection drops - which seems counterintuitive, but in fact just means
@@ -20,6 +22,7 @@ class UtilResubscribeNotifier implements ConnectionStateListener {
      * @param client the client to listen to connection state changes on
      * @param callback the resubscribe callback
      */
+    @ObjectiveCName("init:callback:")
     public UtilResubscribeNotifier(DeepstreamClientAbstract client, UtilResubscribeListener callback) {
         this.client = client;
         this.resubscribe = callback;
@@ -41,6 +44,7 @@ class UtilResubscribeNotifier implements ConnectionStateListener {
      * @see ConnectionStateListener
      */
     @Override
+    @ObjectiveCName("connectionStateChanged:")
     public void connectionStateChanged(ConnectionState state) {
         if( state == ConnectionState.RECONNECTING && !this.isReconnecting) {
                 this.isReconnecting = true;

--- a/src/main/java/io/deepstream/UtilSingleNotifier.java
+++ b/src/main/java/io/deepstream/UtilSingleNotifier.java
@@ -1,5 +1,7 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,6 +26,7 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
      * @param action The Action
      * @param timeoutDuration The timeout duration before an ack timeout is triggered
      */
+    @ObjectiveCName("init:connection:topic:action:timeoutDuration:")
     public UtilSingleNotifier(DeepstreamClientAbstract client, IConnection connection, Topic topic, Actions action, int timeoutDuration ) {
         this.ackTimeoutRegistry = client.getAckTimeoutRegistry();
         this.connection = connection;
@@ -40,6 +43,7 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
      * @param name The name of the object being requested
      * @return true if the request exists
      */
+    @ObjectiveCName("hasRequest:")
     public boolean hasRequest( String name ) {
         return requests.containsKey( name );
     }
@@ -51,6 +55,7 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
      * @param name The name of the object being requested
      * @param utilSingleNotifierCallback The callback to call once the request is completed
      */
+    @ObjectiveCName("request:utilSingleNotifierCallback")
     public void request( String name, UtilSingleNotifierCallback utilSingleNotifierCallback ) {
         ArrayList<UtilSingleNotifierCallback> callbacks = requests.get( name );
         if( callbacks == null ) {
@@ -73,6 +78,7 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
      * @param error An error that may have occurred during the request
      * @param data The result data from the request
      */
+    @ObjectiveCName("recieve:error:data:")
     public void recieve(String name, DeepstreamError error, Object data) {
         ArrayList<UtilSingleNotifierCallback> callbacks = requests.get( name );
         for (UtilSingleNotifierCallback callback : callbacks) {
@@ -93,18 +99,22 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
         }
     }
 
+    @ObjectiveCName("send:")
     private void send( String name ) {
         connection.send( MessageBuilder.getMsg( topic, action, name ) );
     }
 
     @Override
+    @ObjectiveCName("onTimeout:action:event:name:")
     public void onTimeout(Topic topic, Actions action, Event event, String name) {
         this.recieve(name, new DeepstreamError(String.format("Response for % timed out", name)), null);
     }
 
     interface UtilSingleNotifierCallback {
+        @ObjectiveCName("onSingleNotifierError:error:")
         void onSingleNotifierError(String name, DeepstreamError error);
-
+        
+        @ObjectiveCName("onSingleNotifierResponse:data:")
         void onSingleNotifierResponse(String name, Object data);
     }
 }

--- a/src/main/java/io/deepstream/UtilSingleNotifier.java
+++ b/src/main/java/io/deepstream/UtilSingleNotifier.java
@@ -55,7 +55,7 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
      * @param name The name of the object being requested
      * @param utilSingleNotifierCallback The callback to call once the request is completed
      */
-    @ObjectiveCName("request:utilSingleNotifierCallback")
+    @ObjectiveCName("request:utilSingleNotifierCallback:")
     public void request( String name, UtilSingleNotifierCallback utilSingleNotifierCallback ) {
         ArrayList<UtilSingleNotifierCallback> callbacks = requests.get( name );
         if( callbacks == null ) {

--- a/src/main/java/io/deepstream/UtilTimeoutListener.java
+++ b/src/main/java/io/deepstream/UtilTimeoutListener.java
@@ -1,5 +1,8 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 interface UtilTimeoutListener {
+	@ObjectiveCName("onTimeout:action:event:name:")
     void onTimeout(Topic topic, Actions action, Event event, String name );
 }


### PR DESCRIPTION
This pull request includes the following changes:

- Added a `prefixes.properties` file, which removes the package name prefix from methods. E.g. `IODeepstream_set_withNSString(...` will become simply `set_withNSString(...`

- Adds dependency of `com.google.j2objc:j2objc-annotations:1.1` so that the `@ObjectiveCName` annotation can be used to further clean the method names. E.g. from `set_withNSString(` to `set(`

- Added `@ObjectiveCName` annotations.

- Adds additional compilation arguments to the j2ObjC gradle wrapper to enable bitcode, reduce file size by removing unnecessary functionality and reference the prefixes file.