### PR TITLE
Fixing closed event not called

### DIFF
--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -361,6 +361,11 @@ class Connection implements IConnection {
         } else {
             this.clearReconnect();
             this.close();
+            try {
+                this.onClose();
+            } catch( Exception e ) {
+                e.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
After the reconnects are exhausted close event should be called. This doesn't happen in the iOS version (haven't tested the java client). 