### PR TITLE
Changes to handle WebsocketEndpoint from iOS

### DIFF
--- a/scripts/prepareiOS.sh
+++ b/scripts/prepareiOS.sh
@@ -56,7 +56,8 @@ echo '//
 // J2ObjC requirement for Java Runtime Environment
 #import "JreEmulation.h"
 #import "java/util/ArrayList.h"
-#import "java/util/Properties.h"\n' >> $DS_TMP_DIR/src/DeepstreamIO.h
+#import "java/util/Properties.h"
+#import "java/net/URI.h\n' >> $DS_TMP_DIR/src/DeepstreamIO.h
 
 pushd $TRAVIS_BUILD_DIR/build/j2objcOutputs/src/main/objc
 for f in *.h; do

--- a/scripts/prepareiOS.sh
+++ b/scripts/prepareiOS.sh
@@ -57,7 +57,7 @@ echo '//
 #import "JreEmulation.h"
 #import "java/util/ArrayList.h"
 #import "java/util/Properties.h"
-#import "java/net/URI.h\n' >> $DS_TMP_DIR/src/DeepstreamIO.h
+#import "java/net/URI.h"\n' >> $DS_TMP_DIR/src/DeepstreamIO.h
 
 pushd $TRAVIS_BUILD_DIR/build/j2objcOutputs/src/main/objc
 for f in *.h; do

--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -355,7 +355,6 @@ class Connection implements IConnection {
         return uri;
     }
 
-
     private Endpoint createEndpoint() throws URISyntaxException {
         URI uri = parseUri(url, this.options.getPath());
         Endpoint endpoint = this.endpointFactory.createEndpoint(uri, this);

--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -363,9 +363,6 @@ class Connection implements IConnection {
         return endpoint;
     }
 
-    private native Endpoint createIOSEndpoint(URI uri, Connection connection) /*-[
-    ]-*/;
-
     private void tryReconnect() {
         if( this.reconnectTimeout != null ) {
             return;

--- a/src/main/java/io/deepstream/DeepstreamClient.java
+++ b/src/main/java/io/deepstream/DeepstreamClient.java
@@ -86,9 +86,10 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      * deepstream.io java client
      * @param url URL to connect to. The protocol can be omited, e.g. <host>:<port>
      * @param deepstreamConfig A map of options that extend the ones specified in DefaultConfig.properties
+     * @param endpointFactory An EndpointFactory that returns an Endpoint
      * @throws URISyntaxException Thrown if the url in incorrect
      */
-    //@ObjectiveCName("init:deepstreamConfig:endpointFactory")
+    @ObjectiveCName("init:deepstreamConfig:endpointFactory:")
     DeepstreamClient(final String url, DeepstreamConfig deepstreamConfig, EndpointFactory endpointFactory) throws URISyntaxException {
         this.connection = new Connection(url, deepstreamConfig, this, endpointFactory);
         this.event = new EventHandler(deepstreamConfig, this.connection, this);
@@ -96,7 +97,6 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
         this.record = new RecordHandler(deepstreamConfig, this.connection, this);
         this.presence = new PresenceHandler(deepstreamConfig, this.connection, this);
     }
-
 
     /**
      * Gets the {@link RecordHandler} used for data-sync in deepstream. Through records and lists {@link RecordHandler#getRecord(String)},

--- a/src/main/java/io/deepstream/DeepstreamClient.java
+++ b/src/main/java/io/deepstream/DeepstreamClient.java
@@ -74,6 +74,39 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
     /**
      * deepstream.io java client
      * @param url URL to connect to. The protocol can be omited, e.g. <host>:<port>
+     * @param endpointFactory An EndpointFactory that returns an Endpoint
+     * @throws URISyntaxException Thrown if the url in incorrect
+     */
+    @ObjectiveCName("init:endpointFactory:")
+    public DeepstreamClient(final String url, EndpointFactory endpointFactory) throws URISyntaxException, InvalidDeepstreamConfig{
+        this(url, new DeepstreamConfig(), endpointFactory);
+    }
+
+    /**
+     * deepstream.io java client
+     * @param url URL to connect to. The protocol can be omited, e.g. <host>:<port>
+     * @param endpointFactory An EndpointFactory that returns an Endpoint
+     * @throws URISyntaxException Thrown if the url in incorrect
+     */
+    @ObjectiveCName("init:options:endpointFactory:")
+    public DeepstreamClient(final String url, Properties options, EndpointFactory endpointFactory) throws URISyntaxException, InvalidDeepstreamConfig {
+        this(url, new DeepstreamConfig(options), endpointFactory);
+    }
+
+    /**
+     * deepstream.io java client
+     * @param url URL to connect to. The protocol can be omited, e.g. <host>:<port>
+     * @param endpointFactory An EndpointFactory that returns an Endpoint
+     * @throws URISyntaxException Thrown if the url in incorrect
+     */
+    @ObjectiveCName("init:properties:endpointFactory:")
+    public DeepstreamClient(final String url, Map options, EndpointFactory endpointFactory) throws URISyntaxException, InvalidDeepstreamConfig {
+        this(url, new DeepstreamConfig(options), endpointFactory);
+    }
+
+    /**
+     * deepstream.io java client
+     * @param url URL to connect to. The protocol can be omited, e.g. <host>:<port>
      * @param deepstreamConfig A map of options that extend the ones specified in DefaultConfig.properties
      * @throws URISyntaxException Thrown if the url in incorrect
      */
@@ -90,7 +123,7 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
      * @throws URISyntaxException Thrown if the url in incorrect
      */
     @ObjectiveCName("init:deepstreamConfig:endpointFactory:")
-    DeepstreamClient(final String url, DeepstreamConfig deepstreamConfig, EndpointFactory endpointFactory) throws URISyntaxException {
+    public DeepstreamClient(final String url, DeepstreamConfig deepstreamConfig, EndpointFactory endpointFactory) throws URISyntaxException {
         this.connection = new Connection(url, deepstreamConfig, this, endpointFactory);
         this.event = new EventHandler(deepstreamConfig, this.connection, this);
         this.rpc = new RpcHandler(deepstreamConfig, this.connection, this);

--- a/src/main/java/io/deepstream/EndpointFactory.java
+++ b/src/main/java/io/deepstream/EndpointFactory.java
@@ -1,8 +1,11 @@
 package io.deepstream;
 
+import com.google.j2objc.annotations.ObjectiveCName;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 
 interface EndpointFactory {
+	@ObjectiveCName("createEndpoint:connection:")
     public Endpoint createEndpoint(URI uri, Connection connection) throws URISyntaxException;
 }

--- a/src/main/java/io/deepstream/EndpointFactory.java
+++ b/src/main/java/io/deepstream/EndpointFactory.java
@@ -6,6 +6,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 interface EndpointFactory {
-	@ObjectiveCName("createEndpoint:connection:")
+    @ObjectiveCName("createEndpoint:connection:")
     public Endpoint createEndpoint(URI uri, Connection connection) throws URISyntaxException;
 }

--- a/src/main/java/io/deepstream/EndpointWebsocket.java
+++ b/src/main/java/io/deepstream/EndpointWebsocket.java
@@ -14,7 +14,6 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 
-@J2ObjCIncompatible
 class EndpointWebsocket implements Endpoint {
 
     private final URI uri;
@@ -92,9 +91,3 @@ class EndpointWebsocket implements Endpoint {
         }
     }
 }
-
-/*-[
-class EndpointWebsocket implements Endpoint {
-
-}
--*/;

--- a/swift/DeepstreamClient+Extensions.swift
+++ b/swift/DeepstreamClient+Extensions.swift
@@ -3,7 +3,7 @@
 //  DeepstreamIO
 //
 //  Created by Akram Hussein on 17/12/2016.
-//  Copyright (c) 2016 deepstreamHub GmbH. All rights reserved.
+//  Copyright (c) 2017 deepstreamHub GmbH. All rights reserved.
 //
 
 import Foundation

--- a/swift/GSON+Types.swift
+++ b/swift/GSON+Types.swift
@@ -3,7 +3,7 @@
 //  DeepstreamIO
 //
 //  Created by Akram Hussein on 18/12/2016.
-//
+//  Copyright (c) 2017 deepstreamHub GmbH. All rights reserved.
 //
 
 import Foundation

--- a/swift/IOSDeepstreamFactory.swift
+++ b/swift/IOSDeepstreamFactory.swift
@@ -1,0 +1,96 @@
+//
+//  IOSDeepstreamFactory.swift
+//  DeepstreamIO
+//
+//  Created by Akram Hussein on 18/03/2017.
+//  Copyright (c) 2017 deepstreamHub GmbH. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * A singleton to stop you ( the developer ) from having to pass around the deepstream client reference
+ * around the codebase, making application development easier in frameworks such android.
+ * <p>
+ * Currently this only contains a single deepstream client;
+ */
+public final class IOSDeepstreamFactory {
+
+    private static let ourInstance = IOSDeepstreamFactory()
+    private var clients = [String : DeepstreamClient]()
+    private var lastUrl : String?
+
+    public static func getInstance() -> IOSDeepstreamFactory {
+        return ourInstance
+    }
+
+    /**
+     * Returns the last client that was created. This is useful for most applications that
+     * only require a single connection. The first time a client is connected however it has to be
+     * via {@link DeepstreamFactory#getClient(String)} or {@link DeepstreamFactory#getClient(String, Properties)}
+     *
+     * @return A deepstream client
+     */
+
+    public func getClient() -> DeepstreamClient? {
+        guard let lastUrl = self.lastUrl else {
+            return nil
+        }
+
+        guard let client = self.clients[lastUrl] else {
+            return nil
+        }
+
+        return client
+    }
+
+    /**
+     * Returns a client that was previous created via the same url using this method or {@link DeepstreamFactory#getClient(String, Properties)}.
+     * If one wasn't created, it creates it first and stores it for future reference.
+     *
+     * @param url The url to connect to, also the key used to retrieve in future calls
+     * @return A deepstream client
+     * @throws URISyntaxException An error if the url syntax is invalid
+     */
+    public func getClient(url: String) -> DeepstreamClient? {
+        self.lastUrl = url
+
+        // Check if client exists and not in closed/error state
+        guard let c = self.clients[url], self.clientNotAvailable(client: c) else {
+            let client = DeepstreamClient(url, endpointFactory: IOSEndpointWebsocketFactory())
+            self.clients[url] = client
+            return client
+        }
+
+        return c
+    }
+
+    /**
+     * Returns a client that was previous created via the same url using this method or {@link DeepstreamFactory#getClient(String)}.
+     * If one wasn't created, it creates it first and stores it for future reference.
+     *
+     * @param url     The url to connect to, also the key used to retrieve in future calls
+     * @param options The options to use within the deepstream connection
+     * @return A deepstream client
+     * @throws URISyntaxException      An error if the url syntax is invalid
+     * @throws InvalidDeepstreamConfig An exception if any of the options are invalid
+     */
+    public func getClient(url: String, options: JavaUtilProperties) -> DeepstreamClient? {
+        self.lastUrl = url
+
+        // Check if client exists and not in closed/error state
+        guard let c = self.clients[url], self.clientNotAvailable(client: c) else {
+            let client = DeepstreamClient(url, options: options, endpointFactory: IOSEndpointWebsocketFactory())
+            self.clients[url] = client
+            return client
+        }
+
+        return c
+    }
+
+    private func clientNotAvailable(client: DeepstreamClient) -> Bool {
+        let isClosed = (client.getConnectionState().toNSEnum() == ConnectionState_Enum.CLOSED)
+        let isError = (client.getConnectionState().toNSEnum() == ConnectionState_Enum.ERROR)
+        return isClosed || isError
+    }
+}

--- a/swift/IOSEndpointWebsocket.swift
+++ b/swift/IOSEndpointWebsocket.swift
@@ -1,0 +1,76 @@
+//
+//  iOSEndpoint.swift
+//  DeepstreamIO
+//
+//  Created by Akram Hussein on 18/03/2017.
+//  Copyright (c) 2017 deepstreamHub GmbH. All rights reserved.
+//
+
+import Starscream
+
+public final class IOSEndpointWebsocket : NSObject, Endpoint {
+
+    private let uri : JavaNetURI!
+    public let connection : Connection!
+    private var webSocket : WebSocket? {
+        didSet {
+            self.webSocket?.onConnect = {
+                print("Websocket: websocketDidConnect")
+                self.connection.onOpen()
+            }
+
+            self.webSocket?.onDisconnect = { (error: NSError?) in
+                print("Websocket: websocketDidDisconnect")
+                if (error != nil) {
+                    print("Websocket: \(error?.localizedDescription)")
+                    self.connection.onError("error")
+                    return
+                }
+                self.connection.onClose()
+            }
+
+            self.webSocket?.onText = { (text: String) in
+                print("Websocket: websocketDidReceiveMessage, \(text)")
+                self.connection.onMessage(text)
+            }
+
+            self.webSocket?.onData = { (data: Data) in
+                print("Websocket [Unhandled): websocketDidReceiveData \(data)")
+            }
+
+        }
+    }
+
+    public init(uri: JavaNetURI, connection: Connection) {
+        self.uri = uri
+        self.connection = connection
+    }
+
+    public func send(_ message: String!) {
+        print("IOSEndpointWebsocket: \(message!)")
+        self.webSocket?.write(string: message)
+    }
+
+    public func close() {
+        print("IOSEndpointWebsocket: Close")
+        self.webSocket?.disconnect()
+        self.webSocket = nil
+        self.connection.onClose()
+    }
+
+    public func forceClose() {
+        print("Websocket: Force close")
+        self.webSocket?.disconnect(forceTimeout: nil, closeCode: 1)
+    }
+
+    public func open() {
+        guard let url = URL(string: self.uri.toASCIIString()) else {
+            print("IOSEndpointWebsocket Error: Invalid url")
+            return
+        }
+
+        print("IOSEndpointWebsocket: Open on \(url)")
+        self.webSocket = WebSocket(url: url)
+        self.webSocket?.connect()
+    }
+}

--- a/swift/IOSEndpointWebsocketFactory.swift
+++ b/swift/IOSEndpointWebsocketFactory.swift
@@ -1,0 +1,15 @@
+//
+//  IOSEndpointWebsocketFactory.swift
+//  DeepstreamIO
+//
+//  Created by Akram Hussein on 18/03/2017.
+//  Copyright (c) 2017 deepstreamHub GmbH. All rights reserved.
+//
+
+import Foundation
+
+public final class IOSEndpointWebsocketFactory : NSObject, EndpointFactory {
+    public func createEndpoint(_ uri: JavaNetURI!, connection: Connection!) -> Endpoint! {
+        return IOSEndpointWebsocket(uri: uri, connection: connection)
+    }
+}

--- a/swift/JavaUtilProperties+Extension.swift
+++ b/swift/JavaUtilProperties+Extension.swift
@@ -3,7 +3,7 @@
 //  DeepstreamIO
 //
 //  Created by Akram Hussein on 18/12/2016.
-//  Copyright (c) 2016 deepstreamHub GmbH. All rights reserved.
+//  Copyright (c) 2017 deepstreamHub GmbH. All rights reserved.
 //
 
 import Foundation


### PR DESCRIPTION
- Added new `public` constructors to facilitate passing in `EndpointFactory` from iOS with/without properties etc.
 
- Added @ObjectiveCName decorators.

- Updated `prepareiOS.sh` script to include additional Java package (Java Net URI).

- Added Swift extensions for iOS Client for new `IOSDeepstreamFactory`.