### PR TITLE
fix(record): pass action into send method on record set with ack

### DIFF
--- a/src/main/java/io/deepstream/Record.java
+++ b/src/main/java/io/deepstream/Record.java
@@ -318,8 +318,15 @@ public class Record {
             data = new String[]{ this.name(), newVersion, path, MessageBuilder.typed(value), config.toString() };
         }
 
+        Actions action;
+        if (path == null) {
+            action = Actions.UPDATE;
+        } else {
+            action = Actions.PATCH;
+        }
+
         final CountDownLatch snapshotLatch = new CountDownLatch(1);
-        this.recordSetNotifier.request(newVersion, data, new UtilSingleNotifier.UtilSingleNotifierCallback() {
+        this.recordSetNotifier.request(newVersion, action, data, new UtilSingleNotifier.UtilSingleNotifierCallback() {
             @Override
             public void onSingleNotifierError(String name, DeepstreamError error) {
                 result[0] = new RecordSetResult( error.getMessage() );

--- a/src/main/java/io/deepstream/UtilSingleNotifier.java
+++ b/src/main/java/io/deepstream/UtilSingleNotifier.java
@@ -78,15 +78,16 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
      *
      * @param name The name or version to store callbacks on
      * @param data The data to send in the request
+     * @param action The action to send with the request
      * @param utilSingleNotifierCallback The callback to call once the request is completed
      */
-    public void request( String name, String[] data, UtilSingleNotifierCallback utilSingleNotifierCallback ) {
+    public void request( String name, Actions action, String[] data, UtilSingleNotifierCallback utilSingleNotifierCallback ) {
         ArrayList<UtilSingleNotifierCallback> callbacks = requests.get( name );
         if( callbacks == null ) {
             synchronized (this) {
                 callbacks = new ArrayList<>();
                 requests.put(name, callbacks);
-                send(data);
+                send(action, data);
             }
         }
 
@@ -120,7 +121,7 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
      * data from multiple messages has been merged into one deepstream message to save network
      * traffic.
      *
-     * Used in conjunction with {@link UtilSingleNotifier#request(String, String[], UtilSingleNotifierCallback)}
+     * Used in conjunction with {@link UtilSingleNotifier#request(String, Actions, String[], UtilSingleNotifierCallback)}
      *
      * @param data The data received in the message
      * @param error Any errors from the message
@@ -149,7 +150,7 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
         connection.send( MessageBuilder.getMsg( topic, action, name ) );
     }
 
-    private void send( String[] data ) {
+    private void send( Actions action, String[] data ) {
         connection.send( MessageBuilder.getMsg( topic, action, data ) );
     }
 


### PR DESCRIPTION
The `UtilSingleNotifier` is initialised with an action to begin with. This is suitable in other places ie Record snapshots, however we're using it for write acks as well.

Now we just override the action when sending the write ack.