### PR TITLE
Added global merge strategy

### DIFF
--- a/src/main/java/io/deepstream/ConfigOptions.java
+++ b/src/main/java/io/deepstream/ConfigOptions.java
@@ -67,7 +67,12 @@ public enum ConfigOptions {
      * The number of milliseconds from the moment record.delete() is called until an error is thrown since no delete ack
      * message has been received. Please take into account that the deletion is only complete after the record has been deleted from both cache and storage.
      */
-    RECORD_DELETE_TIMEOUT("recordDeleteTimeout");
+    RECORD_DELETE_TIMEOUT("recordDeleteTimeout"),
+
+    /**
+     * The merge strategy
+     */
+    RECORD_MERGE_STRATEGY("recordMergeStrategy");
 
     private String configOption;
 

--- a/src/main/java/io/deepstream/DeepstreamConfig.java
+++ b/src/main/java/io/deepstream/DeepstreamConfig.java
@@ -37,6 +37,7 @@ class DeepstreamConfig {
             this.getRecordReadAckTimeout();
             this.getRecordReadTimeout();
             this.getRecordDeleteTimeout();
+            this.getRecordMergeStrategy();
         } catch( Exception e ) {
             throw new InvalidDeepstreamConfig();
         }
@@ -88,6 +89,10 @@ class DeepstreamConfig {
 
     int getRecordDeleteTimeout() {
         return Integer.parseInt(getOption(ConfigOptions.RECORD_DELETE_TIMEOUT, "3000"));
+    }
+    
+    MergeStrategy getRecordMergeStrategy() {
+        return MergeStrategy.valueOf(getOption(ConfigOptions.RECORD_MERGE_STRATEGY, "REMOTE_WINS"));
     }
 
     @ObjectiveCName("getOption:defaultValue:")

--- a/src/main/java/io/deepstream/Record.java
+++ b/src/main/java/io/deepstream/Record.java
@@ -66,7 +66,8 @@ public class Record {
         this.isReady = false;
         this.isDestroyed = false;
         this.hasProvider = false;
-
+        this.mergeStrategy = this.deepstreamConfig.getRecordMergeStrategy() != null ?
+                RecordMergeStrategies.INSTANCE.getMergeStrategy(this.deepstreamConfig.getRecordMergeStrategy()) : null ;
         this.recordEventsListeners = new ArrayList<>();
         this.onceRecordReadyListeners = new ArrayList<>();
         this.recordDestroyPendingListeners = new ArrayList<>();


### PR DESCRIPTION
due to crash:

Exception java.lang.NullPointerException: Attempt to invoke interface method 'com.google.gson.JsonElement io.deepstream.RecordMergeStrategy.merge(io.deepstream.Record, com.google.gson.JsonElement, int)' on a null object reference
io.deepstream.Record.recoverRecord (Record.java:629)
io.deepstream.Record.applyUpdate (Record.java:589)
io.deepstream.Record.onMessage (Record.java:520)
io.deepstream.RecordHandler.handle (RecordHandler.java:297)
io.deepstream.Connection$4.run (Connection.java:218)
java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1113)
java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:588)
java.lang.Thread.run (Thread.java:818)