### PR TITLE
Optimize socket reconnect strategy

### DIFF
--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -345,7 +345,7 @@ class Connection implements IConnection {
         this.globalConnectivityState = globalConnectivityState;
         if(globalConnectivityState == GlobalConnectivityState.CONNECTED){
             System.out.println("CONNECTED, global state is " + this.connectionState);
-            if(this.connectionState == ConnectionState.NO_NETWORK_CONNECTIVITY || this.connectionState == ConnectionState.CLOSED || this.connectionState == ConnectionState.ERROR) {
+            if(this.connectionState == ConnectionState.CLOSED || this.connectionState == ConnectionState.ERROR) {
                 tryReconnect();
             }
         }else{
@@ -355,7 +355,7 @@ class Connection implements IConnection {
             this.reconnectTimeout = null;
             this.reconnectionAttempt = 0;
             this.endpoint.forceClose();
-            this.setState(ConnectionState.NO_NETWORK_CONNECTIVITY);
+            this.setState(ConnectionState.CLOSED);
         }
     }
 

--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -33,6 +33,7 @@ class Connection implements IConnection {
     private StringBuilder messageBuffer;
     private String url;
     private ConnectionState connectionState;
+    private GlobalConnectivityState globalConnectivityState;
     private DeepstreamClient.LoginCallback loginCallback;
     private JsonElement authParameters;
 
@@ -75,6 +76,7 @@ class Connection implements IConnection {
         this.originalUrl = url;
         this.url = url;
         this.connectionState = ConnectionState.CLOSED;
+        this.globalConnectivityState = GlobalConnectivityState.DISCONNECTED;
         this.messageBuffer = new StringBuilder();
         this.tooManyAuthAttempts = false;
         this.challengeDenied = false;
@@ -336,6 +338,28 @@ class Connection implements IConnection {
     }
 
     /**
+     * Set global connectivity state.
+     * @param  {GlobalConnectivityState} globalConnectivityState Current global connectivity state
+     */
+    protected void setGlobalConnectivityState(GlobalConnectivityState globalConnectivityState){
+        this.globalConnectivityState = globalConnectivityState;
+        if(globalConnectivityState == GlobalConnectivityState.CONNECTED){
+            System.out.println("CONNECTED, global state is " + this.connectionState);
+            if(this.connectionState == ConnectionState.NO_NETWORK_CONNECTIVITY || this.connectionState == ConnectionState.CLOSED || this.connectionState == ConnectionState.ERROR) {
+                tryReconnect();
+            }
+        }else{
+            if(this.reconnectTimeout != null){
+                this.reconnectTimeout.cancel();
+            }
+            this.reconnectTimeout = null;
+            this.reconnectionAttempt = 0;
+            this.endpoint.forceClose();
+            this.setState(ConnectionState.NO_NETWORK_CONNECTIVITY);
+        }
+    }
+
+    /**
      * Take the url passed when creating the client and ensure the correct
      * protocol is provided
      * @param  {String} url Url passed in by client
@@ -375,17 +399,19 @@ class Connection implements IConnection {
         int maxReconnectInterval = options.getMaxReconnectInterval();
 
         if( this.reconnectionAttempt < maxReconnectAttempts ) {
-            this.setState( ConnectionState.RECONNECTING );
-            this.reconnectTimeout = new Timer();
-            this.reconnectTimeout.schedule(new TimerTask() {
-                public void run() {
-                    tryOpen();
-                }
-            }, Math.min(
-                    reconnectIntervalIncrement * this.reconnectionAttempt,
-                    maxReconnectInterval
-            ));
-            this.reconnectionAttempt++;
+            if(this.globalConnectivityState == GlobalConnectivityState.CONNECTED) {
+                this.setState(ConnectionState.RECONNECTING);
+                this.reconnectTimeout = new Timer();
+                this.reconnectTimeout.schedule(new TimerTask() {
+                    public void run() {
+                        tryOpen();
+                    }
+                }, Math.min(
+                        reconnectIntervalIncrement * this.reconnectionAttempt,
+                        maxReconnectInterval
+                ));
+                this.reconnectionAttempt++;
+            }
 
         } else {
             this.clearReconnect();

--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -344,7 +344,6 @@ class Connection implements IConnection {
     protected void setGlobalConnectivityState(GlobalConnectivityState globalConnectivityState){
         this.globalConnectivityState = globalConnectivityState;
         if(globalConnectivityState == GlobalConnectivityState.CONNECTED){
-            System.out.println("CONNECTED, global state is " + this.connectionState);
             if(this.connectionState == ConnectionState.CLOSED || this.connectionState == ConnectionState.ERROR) {
                 tryReconnect();
             }

--- a/src/main/java/io/deepstream/ConnectionState.java
+++ b/src/main/java/io/deepstream/ConnectionState.java
@@ -5,10 +5,6 @@ package io.deepstream;
  */
 public enum ConnectionState {
     /**
-     * No netwrok connectivity available
-     */
-    NO_NETWORK_CONNECTIVITY,
-    /**
      * Connection is closed, usually due to closing the client or getting multiple authentication rejects
      * from server
      */

--- a/src/main/java/io/deepstream/ConnectionState.java
+++ b/src/main/java/io/deepstream/ConnectionState.java
@@ -5,6 +5,10 @@ package io.deepstream;
  */
 public enum ConnectionState {
     /**
+     * No netwrok connectivity available
+     */
+    NO_NETWORK_CONNECTIVITY,
+    /**
      * Connection is closed, usually due to closing the client or getting multiple authentication rejects
      * from server
      */

--- a/src/main/java/io/deepstream/DeepstreamClient.java
+++ b/src/main/java/io/deepstream/DeepstreamClient.java
@@ -289,6 +289,14 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
     }
 
     /**
+     * Set global connectivity state.
+     * @param  {GlobalConnectivityState} globalConnectivityState Current global connectivity state
+     */
+    public void setGlobalConnectivityState(GlobalConnectivityState globalConnectivityState){
+        this.connection.setGlobalConnectivityState(globalConnectivityState);
+    }
+
+    /**
      * Returns a random string. The first block of characters
      * is a timestamp, in order to allow databases to optimize for semi-
      * sequentuel numberings

--- a/src/main/java/io/deepstream/DeepstreamClient.java
+++ b/src/main/java/io/deepstream/DeepstreamClient.java
@@ -289,7 +289,9 @@ public class DeepstreamClient extends DeepstreamClientAbstract {
     }
 
     /**
-     * Set global connectivity state.
+     * Sets global connectivity state and notifies current connections about it. When connectivity is {@link GlobalConnectivityState#DISCONNECTED)} connection will be closed and
+     * no reconnects will be attempted. If connectivity is set to {@link GlobalConnectivityState#CONNECTED)} and current {@link ConnectionState)} is {@link ConnectionState#CLOSED)}
+     * or {@link ConnectionState#ERROR)} then client will try reconnecting. 
      * @param  {GlobalConnectivityState} globalConnectivityState Current global connectivity state
      */
     public void setGlobalConnectivityState(GlobalConnectivityState globalConnectivityState){

--- a/src/main/java/io/deepstream/GlobalConnectivityState.java
+++ b/src/main/java/io/deepstream/GlobalConnectivityState.java
@@ -1,9 +1,9 @@
 package io.deepstream;
 
-/**
- * Created by horin on 02.08.2017.
- */
 
+/**
+ * Used to indicated current network state.
+ */
 public enum GlobalConnectivityState {
     /**
      * Internet connection is available

--- a/src/main/java/io/deepstream/GlobalConnectivityState.java
+++ b/src/main/java/io/deepstream/GlobalConnectivityState.java
@@ -1,0 +1,16 @@
+package io.deepstream;
+
+/**
+ * Created by horin on 02.08.2017.
+ */
+
+public enum GlobalConnectivityState {
+    /**
+     * Internet connection is available
+     */
+    CONNECTED,
+    /**
+     * Internet connection is unavailable
+     */
+    DISCONNECTED
+}


### PR DESCRIPTION
Right now connection reconnect strategy is implemented to repeatedly (3 times be default) try reconnection and then drop it. This is sufficient enough for local desktop apps which are connected to internet almost always but when working on Android device can lost network connectivity for many reasons. I have implemented global connection state variable which indicates whether network connection is available or not. To use it correctly you must call `setGlobalConnectivityState(GlobalConnectivityState globalConnectivityState)` as soon as you know network state after initialization. This defaults to DISCONNECTED and it blocks any reconnect attempts.

It would be much better to implement Android networkStateListener directyl into deepstream library but since this is java/android client I don't want to narrow it to Android only client.