### PR TITLE
1. crash fix where socket send message when connection is not there

### DIFF
--- a/src/main/java/io/deepstream/Connection.java
+++ b/src/main/java/io/deepstream/Connection.java
@@ -398,7 +398,7 @@ class Connection implements IConnection {
         int maxReconnectInterval = options.getMaxReconnectInterval();
 
         if( this.reconnectionAttempt < maxReconnectAttempts ) {
-            if(this.globalConnectivityState == GlobalConnectivityState.CONNECTED) {
+            if(this.globalConnectivityState == GlobalConnectivityState.DISCONNECTED) {
                 this.setState(ConnectionState.RECONNECTING);
                 this.reconnectTimeout = new Timer();
                 this.reconnectTimeout.schedule(new TimerTask() {

--- a/src/main/java/io/deepstream/DeepstreamClientAbstract.java
+++ b/src/main/java/io/deepstream/DeepstreamClientAbstract.java
@@ -45,11 +45,13 @@ abstract class DeepstreamClientAbstract {
          * Help to diagnose the problem quicker by checking for
          * some mon problems
          */
-        if( event.equals( Event.ACK_TIMEOUT ) || event.equals( Event.RESPONSE_TIMEOUT ) ) {
-            if( getConnectionState().equals( ConnectionState.AWAITING_AUTHENTICATION ) ) {
-                String errMsg = "Your message timed out because you\'re not authenticated. Have you called login()?";
-                onError( Topic.ERROR, Event.NOT_AUTHENTICATED, errMsg );
-                return;
+        if (event != null) {
+            if( event.equals( Event.ACK_TIMEOUT ) || event.equals( Event.RESPONSE_TIMEOUT ) ) {
+                if( getConnectionState().equals( ConnectionState.AWAITING_AUTHENTICATION ) ) {
+                    String errMsg = "Your message timed out because you\'re not authenticated. Have you called login()?";
+                    onError(Topic.ERROR, Event.NOT_AUTHENTICATED, errMsg);
+                    return;
+                }
             }
         }
 

--- a/src/main/java/io/deepstream/JavaEndpointWebsocket.java
+++ b/src/main/java/io/deepstream/JavaEndpointWebsocket.java
@@ -26,7 +26,9 @@ class JavaEndpointWebsocket implements Endpoint {
 
     @Override
     public void send(String message) {
-        this.websocket.send( message );
+        if (this.websocket.isOpen()) {
+            this.websocket.send(message);
+        }
     }
 
     @Override


### PR DESCRIPTION
1. crash fix where socket send message when connection is not there
2. retry of websocket was blocked by a condition in Connection.java
3. crash fix where sometimes event comes null and gives null pointor exception in DeepstreamClientAbstract.java