### PR TITLE
Fixed crash/deadlock due to String.format and entailed race condition + Fix for loosing callbacks

### DIFF
--- a/src/main/java/io/deepstream/UtilSingleNotifier.java
+++ b/src/main/java/io/deepstream/UtilSingleNotifier.java
@@ -61,8 +61,8 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
     @ObjectiveCName("request:utilSingleNotifierCallback:")
     public void request( String name, UtilSingleNotifierCallback utilSingleNotifierCallback ) {
         ArrayList<UtilSingleNotifierCallback> callbacks = requests.get( name );
-        if( callbacks == null ) {
-            synchronized (this) {
+        synchronized (this) {
+            if( callbacks == null ) {
                 callbacks = new ArrayList<UtilSingleNotifierCallback>();
                 requests.put(name, callbacks);
                 send(name);
@@ -84,8 +84,8 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
      */
     public void request( String name, Actions action, String[] data, UtilSingleNotifierCallback utilSingleNotifierCallback ) {
         ArrayList<UtilSingleNotifierCallback> callbacks = requests.get( name );
-        if( callbacks == null ) {
-            synchronized (this) {
+        synchronized (this) {
+            if( callbacks == null ) {
                 callbacks = new ArrayList<UtilSingleNotifierCallback>();
                 requests.put(name, callbacks);
                 send(action, data);

--- a/src/main/java/io/deepstream/UtilSingleNotifier.java
+++ b/src/main/java/io/deepstream/UtilSingleNotifier.java
@@ -164,7 +164,7 @@ class UtilSingleNotifier implements UtilResubscribeNotifier.UtilResubscribeListe
     @Override
     @ObjectiveCName("onTimeout:action:event:name:")
     public void onTimeout(Topic topic, Actions action, Event event, String name) {
-        this.receive(name, new DeepstreamError(String.format("Response for % timed out", name)), null);
+        this.receive(name, new DeepstreamError(String.format("Response for %s timed out", name)), null);
     }
 
     interface UtilSingleNotifierCallback {


### PR DESCRIPTION
**commits:
87b110823b962f239ddaed8eb43df3d9cc6d7576
32d3fc19fe528da75bb27503470e32491067781b**

Fixed String format that caused the timeout thread to crash silently.
That fix revealed a race condition where an NullPointerException was thrown whenever the server response arrived while the timeout executed UtilSingleNotifier.receive(String name, DeepstreamError error, Object data) at the same time.

**commits:
0a4780fca38b51a49d9efa59b39cab95b7e47d10**

Prevent the loss of callbacks when two processes enter the if( callbacks == null ) block at the same time and each process creates its own callbacks object and puts it to the requests map. The process that gets to execute the synchronized block second will override the requests map entry of the first process. This is solved by including the if block into the synchronized block.
